### PR TITLE
feat(cmd/updates) Migrate subcommand to support multithreading

### DIFF
--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -104,6 +104,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 	}
 
 	sem := make(chan struct{}, maxConcurrentHosts)
+	var ctxErr error
 loop:
 	for i, host := range hosts {
 		if noMultithread {
@@ -119,12 +120,13 @@ loop:
 				}(i, host)
 			case <-ctx.Done():
 				wg.Done()
+				ctxErr = ctx.Err()
 				break loop
 			}
 		}
 	}
 	wg.Wait()
-	return errors.Join(errs...)
+	return errors.Join(append(errs, ctxErr)...)
 }
 
 type UpdateStatus struct {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -77,9 +77,9 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 	defer disp.Stop()
 
 	var (
-		errMu   sync.Mutex
+		errMu    sync.Mutex
 		firstErr error
-		wg      sync.WaitGroup
+		wg       sync.WaitGroup
 	)
 
 	processHost := func(i int, host string) {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -60,36 +62,58 @@ var Command = []*cli.Command{
 				ReconnectDelay:       10 * time.Second,
 			}
 
-			// Set up live display
-			disp := display.New(os.Stdout, coreCfg.Hosts, coreCfg.Debug)
-			disp.Start()
-			defer disp.Stop()
-
-			// Iterate over all hosts
-			var lastErr error
-			for i, host := range coreCfg.Hosts {
-				line := disp.Line(i)
-				displayStepCallback := display.NewStepCallback(line)
-				osStatus, boardStatus, err := updates(ctx, host, updatesCfg, deps, displayStepCallback)
-				if errors.Is(err, ErrCannotCheckUpdates) {
-					line.CompleteStep("❓")
-					line.Finish("❓", err.Error())
-					// Offline is unknown, not a fatal failure; don't set lastErr.
-				} else if err != nil {
-					line.CompleteStep("❌")
-					line.FinishError(err.Error())
-					lastErr = err
-					// Continue with other hosts even if one fails
-				} else if osStatus == nil {
-					line.Finish("❓", "update applied, status unverified")
-				} else {
-					emoji, msg := formatUpdateResult(osStatus, boardStatus)
-					line.Finish(emoji, msg)
-				}
-			}
-			return lastErr
+			return runUpdatesForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, updatesCfg, deps, os.Stdout)
 		},
 	},
+}
+
+func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, debug)
+	disp.Start()
+	defer disp.Stop()
+
+	var (
+		errMu   sync.Mutex
+		lastErr error
+		wg      sync.WaitGroup
+	)
+
+	processHost := func(i int, host string) {
+		line := disp.Line(i)
+		displayStepCallback := display.NewStepCallback(line)
+		osStatus, boardStatus, err := updates(ctx, host, cfg, deps, displayStepCallback)
+		switch {
+		case errors.Is(err, ErrCannotCheckUpdates):
+			line.CompleteStep("❓")
+			line.Finish("❓", err.Error())
+			// Offline is unknown, not a fatal failure; don't set lastErr.
+		case err != nil:
+			line.CompleteStep("❌")
+			line.FinishError(err.Error())
+			errMu.Lock()
+			lastErr = err
+			errMu.Unlock()
+		case osStatus == nil:
+			line.Finish("❓", "update applied, status unverified")
+		default:
+			emoji, msg := formatUpdateResult(osStatus, boardStatus)
+			line.Finish(emoji, msg)
+		}
+	}
+
+	for i, host := range hosts {
+		if noMultithread {
+			processHost(i, host)
+		} else {
+			wg.Add(1)
+			go func(idx int, h string) {
+				defer wg.Done()
+				processHost(idx, h)
+			}(i, host)
+		}
+	}
+	wg.Wait()
+	return lastErr
 }
 
 type UpdateStatus struct {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -76,11 +76,10 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 	disp.Start()
 	defer disp.Stop()
 
-	var (
-		errMu    sync.Mutex
-		firstErr error
-		wg       sync.WaitGroup
-	)
+	// errs is indexed by host position so results are collected in host-list
+	// order regardless of goroutine completion order.
+	errs := make([]error, len(hosts))
+	var wg sync.WaitGroup
 
 	processHost := func(i int, host string) {
 		line := disp.Line(i)
@@ -90,15 +89,11 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 		case errors.Is(err, ErrCannotCheckUpdates):
 			line.CompleteStep("❓")
 			line.Finish("❓", err.Error())
-			// Offline is unknown, not a fatal failure; don't set firstErr.
+			// Offline is unknown, not a fatal failure; don't set errs[i].
 		case err != nil:
 			line.CompleteStep("❌")
 			line.FinishError(err.Error())
-			errMu.Lock()
-			if firstErr == nil {
-				firstErr = err
-			}
-			errMu.Unlock()
+			errs[i] = err
 		case osStatus == nil:
 			line.Finish("❓", "update applied, status unverified")
 		default:
@@ -122,7 +117,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 		}
 	}
 	wg.Wait()
-	return firstErr
+	return errors.Join(errs...)
 }
 
 type UpdateStatus struct {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -67,6 +67,10 @@ var Command = []*cli.Command{
 	},
 }
 
+// maxConcurrentHosts limits the number of hosts processed simultaneously in
+// multithread mode to avoid opening too many SSH connections at once.
+const maxConcurrentHosts = 20
+
 func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, debug)
 	disp.Start()
@@ -74,7 +78,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 
 	var (
 		errMu   sync.Mutex
-		lastErr error
+		firstErr error
 		wg      sync.WaitGroup
 	)
 
@@ -86,12 +90,14 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 		case errors.Is(err, ErrCannotCheckUpdates):
 			line.CompleteStep("❓")
 			line.Finish("❓", err.Error())
-			// Offline is unknown, not a fatal failure; don't set lastErr.
+			// Offline is unknown, not a fatal failure; don't set firstErr.
 		case err != nil:
 			line.CompleteStep("❌")
 			line.FinishError(err.Error())
 			errMu.Lock()
-			lastErr = err
+			if firstErr == nil {
+				firstErr = err
+			}
 			errMu.Unlock()
 		case osStatus == nil:
 			line.Finish("❓", "update applied, status unverified")
@@ -101,19 +107,22 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 		}
 	}
 
+	sem := make(chan struct{}, maxConcurrentHosts)
 	for i, host := range hosts {
 		if noMultithread {
 			processHost(i, host)
 		} else {
 			wg.Add(1)
+			sem <- struct{}{}
 			go func(idx int, h string) {
 				defer wg.Done()
+				defer func() { <-sem }()
 				processHost(idx, h)
 			}(i, host)
 		}
 	}
 	wg.Wait()
-	return lastErr
+	return firstErr
 }
 
 type UpdateStatus struct {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -73,6 +73,7 @@ const maxConcurrentHosts = 20
 
 func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, debug)
+	disp.SetConcurrent(!noMultithread)
 	disp.Start()
 	defer disp.Stop()
 
@@ -103,17 +104,23 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 	}
 
 	sem := make(chan struct{}, maxConcurrentHosts)
+loop:
 	for i, host := range hosts {
 		if noMultithread {
 			processHost(i, host)
 		} else {
 			wg.Add(1)
-			sem <- struct{}{}
-			go func(idx int, h string) {
-				defer wg.Done()
-				defer func() { <-sem }()
-				processHost(idx, h)
-			}(i, host)
+			select {
+			case sem <- struct{}{}:
+				go func(idx int, h string) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					processHost(idx, h)
+				}(i, host)
+			case <-ctx.Done():
+				wg.Done()
+				break loop
+			}
 		}
 	}
 	wg.Wait()

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -1472,6 +1472,9 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 				break
 			}
 		}
+		// Hold the connection open briefly so that all goroutines overlap and
+		// maxInFlight is captured while multiple connections are in-flight.
+		time.Sleep(10 * time.Millisecond)
 		runner, err := baseFact(ctx, host)
 		if err != nil {
 			inFlight.Add(-1)
@@ -1518,5 +1521,10 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 		t.Errorf("output missing ❌ for router-apply-fail: %q", output)
 	}
 
+	// Assert that goroutines actually ran concurrently: with the delay above
+	// all 3 goroutines should be in-flight at the same time.
+	if maxInFlight.Load() <= 1 {
+		t.Errorf("expected maxInFlight > 1 (goroutines should run concurrently), got %d", maxInFlight.Load())
+	}
 	t.Logf("peak concurrent SSH connections: %d", maxInFlight.Load())
 }

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -1,12 +1,14 @@
 package updates
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"regexp"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1365,4 +1367,156 @@ func TestUpdatesRouterOSStagingRouterBoardFirmware(t *testing.T) {
 			}
 		})
 	}
+}
+
+// makeRouterSSHFactory returns a factory with configurable per-host command behaviour:
+//   - offlineHosts: check-for-updates returns a DNS error (ErrCannotCheckUpdates path, ❓)
+//   - installErrHosts: update is available but install command fails (hard failure path, ❌)
+//   - all other hosts: RouterOS up to date, no board (success path, ✅)
+func makeRouterSSHFactory(offlineHosts, installErrHosts map[string]bool) func(context.Context, string) (ssh.RunnerInterface, error) {
+	return func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+		return &sshmocks_test.MockRunner{
+			RunFunc: func(cmd string) (string, error) {
+				if cmd == "/system/package/update/check-for-updates" {
+					if offlineHosts[host] {
+						return `  status: ERROR: could not resolve dns name (timeout)`, nil
+					}
+					if installErrHosts[host] {
+						return `  status: New version available
+  installed-version: 7.13.0
+  latest-version: 7.14.1`, nil
+					}
+					return `  status: Updated
+  installed-version: 7.14.1
+  latest-version: 7.14.1`, nil
+				}
+				if cmd == "/system/routerboard/print" {
+					return `  routerboard: no`, nil
+				}
+				if cmd == "/system/package/update/install" {
+					if installErrHosts[host] {
+						return "", fmt.Errorf("permission denied: install not allowed")
+					}
+					return "System will reboot", nil
+				}
+				return "", nil
+			},
+			CloseFunc: func() error { return nil },
+		}, nil
+	}
+}
+
+func TestRunUpdatesForHosts_Sequential(t *testing.T) {
+	hosts := []string{"router-ok", "router-offline", "router-apply-fail"}
+
+	deps := UpdatesDependencies{
+		SSHConnectionFactory: makeRouterSSHFactory(
+			map[string]bool{"router-offline": true},
+			map[string]bool{"router-apply-fail": true},
+		),
+		ReconnectDelay: 10 * time.Millisecond,
+	}
+
+	cfg := UpdatesConfig{UpdatesApply: true}
+
+	var out bytes.Buffer
+	err := runUpdatesForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	if err == nil {
+		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
+	}
+
+	output := out.String()
+
+	// router-ok: up to date
+	if !strings.Contains(output, "router-ok") {
+		t.Errorf("output missing router-ok line: %q", output)
+	}
+	if !strings.Contains(output, "✅") {
+		t.Errorf("output missing ✅ for router-ok: %q", output)
+	}
+
+	// router-offline: unknown (❓)
+	if !strings.Contains(output, "router-offline") {
+		t.Errorf("output missing router-offline line: %q", output)
+	}
+	if !strings.Contains(output, "❓") {
+		t.Errorf("output missing ❓ for router-offline: %q", output)
+	}
+
+	// router-apply-fail: hard failure (❌)
+	if !strings.Contains(output, "router-apply-fail") {
+		t.Errorf("output missing router-apply-fail line: %q", output)
+	}
+	if !strings.Contains(output, "❌") {
+		t.Errorf("output missing ❌ for router-apply-fail: %q", output)
+	}
+}
+
+func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
+	hosts := []string{"router-ok", "router-offline", "router-apply-fail"}
+
+	// Count concurrent in-flight connections to verify parallelism actually happens.
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	baseFact := makeRouterSSHFactory(
+		map[string]bool{"router-offline": true},
+		map[string]bool{"router-apply-fail": true},
+	)
+
+	countingFact := func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+		current := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if current <= old || maxInFlight.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		runner, err := baseFact(ctx, host)
+		if err != nil {
+			inFlight.Add(-1)
+			return nil, err
+		}
+		orig := runner.(*sshmocks_test.MockRunner)
+		origClose := orig.CloseFunc
+		orig.CloseFunc = func() error {
+			inFlight.Add(-1)
+			if origClose != nil {
+				return origClose()
+			}
+			return nil
+		}
+		return orig, nil
+	}
+
+	deps := UpdatesDependencies{
+		SSHConnectionFactory: countingFact,
+		ReconnectDelay:       10 * time.Millisecond,
+	}
+
+	cfg := UpdatesConfig{UpdatesApply: true}
+
+	var out bytes.Buffer
+	err := runUpdatesForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	if err == nil {
+		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
+	}
+
+	output := out.String()
+
+	// All three hosts must appear in output
+	for _, host := range hosts {
+		if !strings.Contains(output, host) {
+			t.Errorf("output missing %q: %q", host, output)
+		}
+	}
+
+	if !strings.Contains(output, "✅") {
+		t.Errorf("output missing ✅ for router-ok: %q", output)
+	}
+	if !strings.Contains(output, "❌") {
+		t.Errorf("output missing ❌ for router-apply-fail: %q", output)
+	}
+
+	t.Logf("peak concurrent SSH connections: %d", maxInFlight.Load())
 }

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -1459,6 +1459,13 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 	var inFlight atomic.Int32
 	var maxInFlight atomic.Int32
 
+	nHosts := len(hosts)
+	// allStarted is closed once every goroutine has incremented inFlight,
+	// so maxInFlight is captured while all connections are simultaneously
+	// in-flight without relying on timing or sleep.
+	allStarted := make(chan struct{})
+	var startedCount atomic.Int32
+
 	baseFact := makeRouterSSHFactory(
 		map[string]bool{"router-offline": true},
 		map[string]bool{"router-apply-fail": true},
@@ -1472,9 +1479,12 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 				break
 			}
 		}
-		// Hold the connection open briefly so that all goroutines overlap and
-		// maxInFlight is captured while multiple connections are in-flight.
-		time.Sleep(10 * time.Millisecond)
+		// Barrier: block until every goroutine has reached this point.
+		if startedCount.Add(1) == int32(nHosts) {
+			close(allStarted)
+		} else {
+			<-allStarted
+		}
 		runner, err := baseFact(ctx, host)
 		if err != nil {
 			inFlight.Add(-1)

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	User             string
 	Debug            bool
 	SkipHostKeyCheck bool
+	NoMultithread    bool
 }
 
 // GetSkipHostKeyCheck returns the SkipHostKeyCheck flag for host key verification

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -221,6 +221,7 @@ func (d *LiveDisplay) clearNonLive() {
 		l.pending = nil
 	}
 }
+
 // initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
 // Called during initial construction when the display starts in non-live mode,
 // and whenever a live-mode display transitions to non-live mode via Start's

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -26,7 +26,8 @@ type completedStep struct {
 // HostLine tracks the display state for a single host.
 type HostLine struct {
 	mu            sync.Mutex
-	writeMu       *sync.Mutex // shared with LiveDisplay; serialises writes to out in non-live mode
+	index         int    // position in the parent LiveDisplay.pendingLines slice
+	pending       *[]string // points to LiveDisplay.pendingLines; nil in live mode
 	hostname      string
 	hostnameWidth int
 	overallEmoji  string // ⏳ while in-progress; set to the final status emoji by Finish
@@ -36,7 +37,6 @@ type HostLine struct {
 	done          bool
 	finalMessage  string // set by Finish; does not include the hostname or overall emoji
 	liveMode      bool
-	out           io.Writer
 }
 
 // StepCallback is used to update step display for a host.
@@ -76,19 +76,16 @@ func (h *HostLine) CompleteStep(emoji string) {
 // Finish marks the line as done with an overall status emoji and a final message.
 // overallEmoji should be one of ✅, ❌, ❓, ⚠️.
 // message is the human-readable result description (no hostname, no leading emoji).
+// In non-live mode the rendered line is buffered and written to out in host-list
+// order when LiveDisplay.Stop is called.
 func (h *HostLine) Finish(overallEmoji, message string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.done = true
 	h.overallEmoji = overallEmoji
 	h.finalMessage = message
-	if !h.liveMode {
-		h.writeMu.Lock()
-		_, err := fmt.Fprintf(h.out, "%s\n", h.renderUnlocked())
-		h.writeMu.Unlock()
-		if err != nil {
-			slog.Warn("display: failed to write host line", "host", h.hostname, "error", err)
-		}
+	if !h.liveMode && h.pending != nil {
+		(*h.pending)[h.index] = h.renderUnlocked()
 	}
 }
 
@@ -149,10 +146,10 @@ var (
 
 // LiveDisplay manages per-host live output lines.
 type LiveDisplay struct {
-	lines    []*HostLine
-	liveMode bool
-	out      io.Writer
-	writeMu  sync.Mutex // serialises writes to out across all HostLines in non-live mode
+	lines        []*HostLine
+	liveMode     bool
+	out          io.Writer
+	pendingLines []string // non-live mode: one buffered output line per host, flushed in order by Stop
 }
 
 // New creates a LiveDisplay. If debug=true or stdout is not a TTY, falls back to verbose mode.
@@ -170,14 +167,22 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 		liveMode: liveMode,
 		out:      out,
 	}
+
+	var pending *[]string
+	if !liveMode {
+		slots := make([]string, len(hosts))
+		d.pendingLines = slots
+		pending = &d.pendingLines
+	}
+
 	for i, host := range hosts {
 		d.lines[i] = &HostLine{
 			hostname:      host,
 			hostnameWidth: hostnameWidth,
 			overallEmoji:  "⏳",
 			liveMode:      liveMode,
-			out:           out,
-			writeMu:       &d.writeMu,
+			index:         i,
+			pending:       pending,
 		}
 	}
 	return d
@@ -241,14 +246,24 @@ func (d *LiveDisplay) release() {
 	}
 }
 
-// Stop finalises live output. In fallback mode this is a no-op.
+// Stop finalises output. In live mode it stops liveterm. In non-live mode it
+// flushes all buffered host lines to out in host-list order, so that concurrent
+// goroutines that finish at different times still produce deterministic output.
 func (d *LiveDisplay) Stop() {
-	if !d.liveMode {
+	if d.liveMode {
+		defer d.release()
+		if err := liveterm.Stop(false); err != nil {
+			slog.Warn("display: failed to stop live terminal", "error", err)
+		}
 		return
 	}
-	defer d.release()
-	if err := liveterm.Stop(false); err != nil {
-		slog.Warn("display: failed to stop live terminal", "error", err)
+	for _, line := range d.pendingLines {
+		if line == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(d.out, "%s\n", line); err != nil {
+			slog.Warn("display: failed to write host line", "error", err)
+		}
 	}
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -26,6 +26,7 @@ type completedStep struct {
 // HostLine tracks the display state for a single host.
 type HostLine struct {
 	mu            sync.Mutex
+	writeMu       *sync.Mutex // shared with LiveDisplay; serialises writes to out in non-live mode
 	hostname      string
 	hostnameWidth int
 	overallEmoji  string // ⏳ while in-progress; set to the final status emoji by Finish
@@ -82,7 +83,10 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 	h.overallEmoji = overallEmoji
 	h.finalMessage = message
 	if !h.liveMode {
-		if _, err := fmt.Fprintf(h.out, "%s\n", h.renderUnlocked()); err != nil {
+		h.writeMu.Lock()
+		_, err := fmt.Fprintf(h.out, "%s\n", h.renderUnlocked())
+		h.writeMu.Unlock()
+		if err != nil {
 			slog.Warn("display: failed to write host line", "host", h.hostname, "error", err)
 		}
 	}
@@ -148,6 +152,7 @@ type LiveDisplay struct {
 	lines    []*HostLine
 	liveMode bool
 	out      io.Writer
+	writeMu  sync.Mutex // serialises writes to out across all HostLines in non-live mode
 }
 
 // New creates a LiveDisplay. If debug=true or stdout is not a TTY, falls back to verbose mode.
@@ -160,22 +165,22 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 	}
 	hostnameWidth := computeHostnameWidth(hosts)
 
-	lines := make([]*HostLine, len(hosts))
+	d := &LiveDisplay{
+		lines:    make([]*HostLine, len(hosts)),
+		liveMode: liveMode,
+		out:      out,
+	}
 	for i, host := range hosts {
-		lines[i] = &HostLine{
+		d.lines[i] = &HostLine{
 			hostname:      host,
 			hostnameWidth: hostnameWidth,
 			overallEmoji:  "⏳",
 			liveMode:      liveMode,
 			out:           out,
+			writeMu:       &d.writeMu,
 		}
 	}
-
-	return &LiveDisplay{
-		lines:    lines,
-		liveMode: liveMode,
-		out:      out,
-	}
+	return d
 }
 
 // Line returns the HostLine for the i-th host (0-indexed).

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -84,7 +84,7 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 	h.done = true
 	h.overallEmoji = overallEmoji
 	h.finalMessage = message
-	if !h.liveMode && h.pending != nil {
+	if !h.liveMode {
 		(*h.pending)[h.index] = h.renderUnlocked()
 	}
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -92,7 +92,9 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 			(*h.pending)[h.index] = h.renderUnlocked()
 		} else {
 			// sequential mode: write immediately for real-time feedback
-			fmt.Fprintf(h.out, "%s\n", h.renderUnlocked())
+			if _, err := fmt.Fprintf(h.out, "%s\n", h.renderUnlocked()); err != nil {
+				slog.Warn("failed to write host output", "host", h.hostname, "error", err)
+			}
 		}
 	}
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -93,7 +93,7 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 		} else {
 			// sequential mode: write immediately for real-time feedback
 			if _, err := fmt.Fprintf(h.out, "%s\n", h.renderUnlocked()); err != nil {
-				slog.Warn("failed to write host output", "host", h.hostname, "error", err)
+				slog.Warn("display: failed to write host output", "host", h.hostname, "error", err)
 			}
 		}
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -26,7 +26,7 @@ type completedStep struct {
 // HostLine tracks the display state for a single host.
 type HostLine struct {
 	mu            sync.Mutex
-	index         int    // position in the parent LiveDisplay.pendingLines slice
+	index         int       // position in the parent LiveDisplay.pendingLines slice
 	pending       *[]string // points to LiveDisplay.pendingLines; nil in live mode
 	hostname      string
 	hostnameWidth int

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -168,13 +168,6 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 		out:      out,
 	}
 
-	var pending *[]string
-	if !liveMode {
-		slots := make([]string, len(hosts))
-		d.pendingLines = slots
-		pending = &d.pendingLines
-	}
-
 	for i, host := range hosts {
 		d.lines[i] = &HostLine{
 			hostname:      host,
@@ -182,10 +175,23 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 			overallEmoji:  "⏳",
 			liveMode:      liveMode,
 			index:         i,
-			pending:       pending,
 		}
 	}
+
+	if !liveMode {
+		d.initNonLive()
+	}
+
 	return d
+}
+
+// initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
+// Must be called whenever the display transitions to non-live mode.
+func (d *LiveDisplay) initNonLive() {
+	d.pendingLines = make([]string, len(d.lines))
+	for _, l := range d.lines {
+		l.pending = &d.pendingLines
+	}
 }
 
 // Line returns the HostLine for the i-th host (0-indexed).
@@ -210,6 +216,7 @@ func (d *LiveDisplay) Start() {
 		for _, l := range d.lines {
 			l.liveMode = false
 		}
+		d.initNonLive()
 		return
 	}
 
@@ -223,6 +230,7 @@ func (d *LiveDisplay) Start() {
 		for _, l := range d.lines {
 			l.liveMode = false
 		}
+		d.initNonLive()
 	}
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -156,7 +156,7 @@ var (
 type LiveDisplay struct {
 	lines        []*HostLine
 	liveMode     bool
-	concurrent   bool   // when true, non-live Finish buffers; Stop flushes in host-list order
+	concurrent   bool // when true, non-live Finish buffers; Stop flushes in host-list order
 	out          io.Writer
 	pendingLines []string // non-live concurrent mode: one buffered output line per host, flushed in order by Stop
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -186,7 +186,9 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 }
 
 // initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
-// Must be called whenever the display transitions to non-live mode.
+// Called during initial construction when the display starts in non-live mode,
+// and whenever a live-mode display transitions to non-live mode via Start's
+// fallback paths (singleton contention or liveterm.Start failure).
 func (d *LiveDisplay) initNonLive() {
 	d.pendingLines = make([]string, len(d.lines))
 	for _, l := range d.lines {

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -27,7 +27,8 @@ type completedStep struct {
 type HostLine struct {
 	mu            sync.Mutex
 	index         int       // position in the parent LiveDisplay.pendingLines slice
-	pending       *[]string // points to LiveDisplay.pendingLines; nil in live mode
+	pending       *[]string // points to LiveDisplay.pendingLines; nil when not buffering (sequential non-live)
+	out           io.Writer // used for immediate writes in sequential non-live mode
 	hostname      string
 	hostnameWidth int
 	overallEmoji  string // ⏳ while in-progress; set to the final status emoji by Finish
@@ -76,8 +77,9 @@ func (h *HostLine) CompleteStep(emoji string) {
 // Finish marks the line as done with an overall status emoji and a final message.
 // overallEmoji should be one of ✅, ❌, ❓, ⚠️.
 // message is the human-readable result description (no hostname, no leading emoji).
-// In non-live mode the rendered line is buffered and written to out in host-list
-// order when LiveDisplay.Stop is called.
+// In concurrent non-live mode the rendered line is buffered and written to out in
+// host-list order when LiveDisplay.Stop is called. In sequential non-live mode the
+// line is written immediately so the caller sees progress in real time.
 func (h *HostLine) Finish(overallEmoji, message string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -85,7 +87,13 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 	h.overallEmoji = overallEmoji
 	h.finalMessage = message
 	if !h.liveMode {
-		(*h.pending)[h.index] = h.renderUnlocked()
+		if h.pending != nil {
+			// concurrent mode: buffer for ordered flush in Stop
+			(*h.pending)[h.index] = h.renderUnlocked()
+		} else {
+			// sequential mode: write immediately for real-time feedback
+			fmt.Fprintf(h.out, "%s\n", h.renderUnlocked())
+		}
 	}
 }
 
@@ -148,8 +156,9 @@ var (
 type LiveDisplay struct {
 	lines        []*HostLine
 	liveMode     bool
+	concurrent   bool   // when true, non-live Finish buffers; Stop flushes in host-list order
 	out          io.Writer
-	pendingLines []string // non-live mode: one buffered output line per host, flushed in order by Stop
+	pendingLines []string // non-live concurrent mode: one buffered output line per host, flushed in order by Stop
 }
 
 // New creates a LiveDisplay. If debug=true or stdout is not a TTY, falls back to verbose mode.
@@ -175,14 +184,27 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 			overallEmoji:  "⏳",
 			liveMode:      liveMode,
 			index:         i,
+			out:           out,
 		}
 	}
 
-	if !liveMode {
+	return d
+}
+
+// SetConcurrent marks the display as serving concurrent host processing.
+// Must be called before Start. In concurrent non-live mode, HostLine.Finish
+// buffers each line and LiveDisplay.Stop flushes them in host-list order so
+// that output is deterministic regardless of goroutine completion order.
+// In the default sequential mode, Finish writes each line immediately so the
+// caller sees per-host progress in real time.
+func (d *LiveDisplay) SetConcurrent(concurrent bool) {
+	d.concurrent = concurrent
+	// If we are already in non-live mode (e.g. debug=true) and switching to
+	// concurrent, initialise the pending buffer now so that HostLine.Finish
+	// can start buffering without waiting for Start to be called.
+	if concurrent && !d.liveMode && d.pendingLines == nil {
 		d.initNonLive()
 	}
-
-	return d
 }
 
 // initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
@@ -218,7 +240,9 @@ func (d *LiveDisplay) Start() {
 		for _, l := range d.lines {
 			l.liveMode = false
 		}
-		d.initNonLive()
+		if d.concurrent {
+			d.initNonLive()
+		}
 		return
 	}
 
@@ -232,7 +256,9 @@ func (d *LiveDisplay) Start() {
 		for _, l := range d.lines {
 			l.liveMode = false
 		}
-		d.initNonLive()
+		if d.concurrent {
+			d.initNonLive()
+		}
 	}
 }
 
@@ -256,8 +282,8 @@ func (d *LiveDisplay) release() {
 	}
 }
 
-// Stop finalises output. In live mode it stops liveterm. In non-live mode it
-// flushes all buffered host lines to out in host-list order, so that concurrent
+// Stop finalises output. In live mode it stops liveterm. In concurrent non-live
+// mode it flushes all buffered host lines to out in host-list order, so that
 // goroutines that finish at different times still produce deterministic output.
 func (d *LiveDisplay) Stop() {
 	if d.liveMode {
@@ -267,12 +293,12 @@ func (d *LiveDisplay) Stop() {
 		}
 		return
 	}
-	for _, line := range d.pendingLines {
+	for i, line := range d.pendingLines {
 		if line == "" {
 			continue
 		}
 		if _, err := fmt.Fprintf(d.out, "%s\n", line); err != nil {
-			slog.Warn("display: failed to write host line", "error", err)
+			slog.Warn("display: failed to write host line", "error", err, "line_index", i, "hostname", d.lines[i].hostname)
 		}
 	}
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -201,14 +201,26 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 // caller sees per-host progress in real time.
 func (d *LiveDisplay) SetConcurrent(concurrent bool) {
 	d.concurrent = concurrent
+	if !concurrent {
+		d.clearNonLive()
+		return
+	}
 	// If we are already in non-live mode (e.g. debug=true) and switching to
 	// concurrent, initialise the pending buffer now so that HostLine.Finish
 	// can start buffering without waiting for Start to be called.
-	if concurrent && !d.liveMode && d.pendingLines == nil {
+	if !d.liveMode && d.pendingLines == nil {
 		d.initNonLive()
 	}
 }
 
+// clearNonLive removes any non-live buffering state so sequential mode writes
+// each line immediately instead of buffering for Stop.
+func (d *LiveDisplay) clearNonLive() {
+	d.pendingLines = nil
+	for _, l := range d.lines {
+		l.pending = nil
+	}
+}
 // initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
 // Called during initial construction when the display starts in non-live mode,
 // and whenever a live-mode display transitions to non-live mode via Start's

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -84,8 +84,7 @@ func TestFinishFallback(t *testing.T) {
 	l.CompleteStep("✅")
 	l.Finish("✅", "is up-to-date (RouterOS: 7.16)")
 
-	// In fallback mode, Finish buffers the rendered line; Stop flushes it to out.
-	d.Stop()
+	// In non-concurrent non-live mode, Finish writes immediately to out.
 	output := buf.String()
 	if !strings.HasPrefix(output, "✅") {
 		t.Errorf("Finish() output = %q, want ✅ overall status at start", output)
@@ -96,6 +95,7 @@ func TestFinishFallback(t *testing.T) {
 	if !strings.Contains(output, "is up-to-date (RouterOS: 7.16)") {
 		t.Errorf("Finish() output = %q, want final message present", output)
 	}
+	d.Stop() // no-op for sequential non-live mode
 
 	// render() after Finish should produce the same line.
 	got := l.render()
@@ -116,7 +116,7 @@ func TestFinishErrorFallback(t *testing.T) {
 	l.CompleteStep("⏳")
 	l.FinishError("updates failed: ssh: connect: timeout")
 
-	d.Stop()
+	// In non-concurrent non-live mode, FinishError writes immediately to out.
 	output := buf.String()
 	if !strings.Contains(output, "❌") {
 		t.Errorf("FinishError() output = %q, want ❌", output)
@@ -124,6 +124,7 @@ func TestFinishErrorFallback(t *testing.T) {
 	if !strings.Contains(output, "badrouter.example.c…") {
 		t.Errorf("FinishError() output = %q, want truncated hostname", output)
 	}
+	d.Stop() // no-op for sequential non-live mode
 }
 
 func TestHostLineThreadSafety(t *testing.T) {
@@ -172,6 +173,7 @@ func TestOutputOrder(t *testing.T) {
 	hosts := []string{"host1.example.com", "host2.example.com", "host3.example.com"}
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, hosts)
+	d.SetConcurrent(true) // enable buffering so Stop flushes in host-list order
 
 	// Finish hosts in reverse order to simulate out-of-order concurrent completion.
 	d.Line(2).Finish("✅", "host3 done")
@@ -420,12 +422,12 @@ func TestSingletonFallback(t *testing.T) {
 		}
 	}
 
-	// In plain-text fallback, Finish buffers the line; Stop flushes it to out in order.
+	// In plain-text fallback (non-concurrent), Finish writes immediately to out.
 	second.Line(0).Finish("✅", "up-to-date")
-	second.Stop()
 	if !strings.Contains(buf2.String(), "router2") {
 		t.Errorf("expected plain-text output for second display after fallback, got %q", buf2.String())
 	}
+	second.Stop() // no-op in non-concurrent non-live mode
 }
 
 // TestSingletonReleasedAfterStop verifies that after Stop the singleton slot

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -37,7 +37,7 @@ func TestNewFallbackMode(t *testing.T) {
 func TestStartStopFallback(t *testing.T) {
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, []string{"router1"})
-	// In fallback mode Start/Stop should be no-ops and not panic.
+	// In fallback mode Start is a no-op; Stop flushes buffered lines (none here).
 	d.Start()
 	d.Stop()
 }
@@ -84,7 +84,8 @@ func TestFinishFallback(t *testing.T) {
 	l.CompleteStep("✅")
 	l.Finish("✅", "is up-to-date (RouterOS: 7.16)")
 
-	// In fallback mode, Finish should write the rendered line to out.
+	// In fallback mode, Finish buffers the rendered line; Stop flushes it to out.
+	d.Stop()
 	output := buf.String()
 	if !strings.HasPrefix(output, "✅") {
 		t.Errorf("Finish() output = %q, want ✅ overall status at start", output)
@@ -115,6 +116,7 @@ func TestFinishErrorFallback(t *testing.T) {
 	l.CompleteStep("⏳")
 	l.FinishError("updates failed: ssh: connect: timeout")
 
+	d.Stop()
 	output := buf.String()
 	if !strings.Contains(output, "❌") {
 		t.Errorf("FinishError() output = %q, want ❌", output)
@@ -155,11 +157,40 @@ func TestMultipleHosts(t *testing.T) {
 		l.Finish("✅", host+" is up-to-date")
 	}
 
+	d.Stop()
 	output := buf.String()
 	for _, host := range hosts {
 		if !strings.Contains(output, host) {
 			t.Errorf("output missing host %q: %s", host, output)
 		}
+	}
+}
+
+// TestOutputOrder verifies that Stop flushes host lines in host-list order even
+// when goroutines call Finish out of order (simulating concurrent completion).
+func TestOutputOrder(t *testing.T) {
+	hosts := []string{"alpha.example.com", "beta.example.com", "gamma.example.com"}
+	var buf bytes.Buffer
+	d := newTestDisplay(&buf, hosts)
+
+	// Finish hosts in reverse order to simulate out-of-order concurrent completion.
+	d.Line(2).Finish("✅", "gamma done")
+	d.Line(0).Finish("✅", "alpha done")
+	d.Line(1).Finish("✅", "beta done")
+
+	d.Stop()
+	output := buf.String()
+
+	// Output must list hosts in the original host-list order.
+	alphaIdx := strings.Index(output, "alpha.example.com")
+	betaIdx := strings.Index(output, "beta.example.com")
+	gammaIdx := strings.Index(output, "gamma.example.com")
+	if alphaIdx < 0 || betaIdx < 0 || gammaIdx < 0 {
+		t.Fatalf("output missing one or more hostnames: %q", output)
+	}
+	if !(alphaIdx < betaIdx && betaIdx < gammaIdx) {
+		t.Errorf("output not in host-list order: alpha=%d beta=%d gamma=%d\n%s",
+			alphaIdx, betaIdx, gammaIdx, output)
 	}
 }
 
@@ -389,8 +420,9 @@ func TestSingletonFallback(t *testing.T) {
 		}
 	}
 
-	// In plain-text fallback, Finish writes directly to the writer.
+	// In plain-text fallback, Finish buffers the line; Stop flushes it to out in order.
 	second.Line(0).Finish("✅", "up-to-date")
+	second.Stop()
 	if !strings.Contains(buf2.String(), "router2") {
 		t.Errorf("expected plain-text output for second display after fallback, got %q", buf2.String())
 	}

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -169,28 +169,28 @@ func TestMultipleHosts(t *testing.T) {
 // TestOutputOrder verifies that Stop flushes host lines in host-list order even
 // when goroutines call Finish out of order (simulating concurrent completion).
 func TestOutputOrder(t *testing.T) {
-	hosts := []string{"alpha.example.com", "beta.example.com", "gamma.example.com"}
+	hosts := []string{"host1.example.com", "host2.example.com", "host3.example.com"}
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, hosts)
 
 	// Finish hosts in reverse order to simulate out-of-order concurrent completion.
-	d.Line(2).Finish("✅", "gamma done")
-	d.Line(0).Finish("✅", "alpha done")
-	d.Line(1).Finish("✅", "beta done")
+	d.Line(2).Finish("✅", "host3 done")
+	d.Line(0).Finish("✅", "host1 done")
+	d.Line(1).Finish("✅", "host2 done")
 
 	d.Stop()
 	output := buf.String()
 
 	// Output must list hosts in the original host-list order.
-	alphaIdx := strings.Index(output, "alpha.example.com")
-	betaIdx := strings.Index(output, "beta.example.com")
-	gammaIdx := strings.Index(output, "gamma.example.com")
-	if alphaIdx < 0 || betaIdx < 0 || gammaIdx < 0 {
+	idx1 := strings.Index(output, "host1.example.com")
+	idx2 := strings.Index(output, "host2.example.com")
+	idx3 := strings.Index(output, "host3.example.com")
+	if idx1 < 0 || idx2 < 0 || idx3 < 0 {
 		t.Fatalf("output missing one or more hostnames: %q", output)
 	}
-	if !(alphaIdx < betaIdx && betaIdx < gammaIdx) {
-		t.Errorf("output not in host-list order: alpha=%d beta=%d gamma=%d\n%s",
-			alphaIdx, betaIdx, gammaIdx, output)
+	if !(idx1 < idx2 && idx2 < idx3) {
+		t.Errorf("output not in host-list order: host1=%d host2=%d host3=%d\n%s",
+			idx1, idx2, idx3, output)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -85,6 +85,12 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Usage:       "Enable debug logging",
 				Destination: &globalConfig.Debug,
 			},
+			&cli.BoolFlag{
+				Name:        "no-multithread",
+				Value:       false,
+				Usage:       "Disable parallel host processing (sequential fallback)",
+				Destination: &globalConfig.NoMultithread,
+			},
 		},
 		Commands: append(append(export.Command, updates.Command...), enroll.Command...),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,7 @@ func TestBuildCommandFlags(t *testing.T) {
 		"ssh-password":   false,
 		"ssh-passphrase": false,
 		"debug":          false,
+		"no-multithread": false,
 	}
 
 	// Check all expected flags exist
@@ -71,8 +72,8 @@ func TestBuildCommandFlags(t *testing.T) {
 	}
 
 	// Test that we have the right number of flags
-	if len(cmd.Flags) != 6 {
-		t.Errorf("Expected 6 flags, got %d", len(cmd.Flags))
+	if len(cmd.Flags) != 7 {
+		t.Errorf("Expected 7 flags, got %d", len(cmd.Flags))
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -47,13 +47,13 @@ func TestBuildCommandFlags(t *testing.T) {
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
 	expectedFlags := map[string]bool{
-		"host":                false,
-		"ssh-user":            false,
-		"ssh-password":        false,
-		"ssh-passphrase":      false,
-		"debug":               false,
-		"no-multithread":      false,
-		"skip-hostkey-check":  false,
+		"host":               false,
+		"ssh-user":           false,
+		"ssh-password":       false,
+		"ssh-passphrase":     false,
+		"debug":              false,
+		"no-multithread":     false,
+		"skip-hostkey-check": false,
 	}
 
 	// Check all expected flags exist

--- a/main_test.go
+++ b/main_test.go
@@ -47,12 +47,13 @@ func TestBuildCommandFlags(t *testing.T) {
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
 	expectedFlags := map[string]bool{
-		"host":           false,
-		"ssh-user":       false,
-		"ssh-password":   false,
-		"ssh-passphrase": false,
-		"debug":          false,
-		"no-multithread": false,
+		"host":                false,
+		"ssh-user":            false,
+		"ssh-password":        false,
+		"ssh-passphrase":      false,
+		"debug":               false,
+		"no-multithread":      false,
+		"skip-hostkey-check":  false,
 	}
 
 	// Check all expected flags exist


### PR DESCRIPTION
Allows the tools to parallelize updates checks.

Change summary:
* Add a global command line to control multithreading. Default is enabled
* Migrate updates subcommand to leverage multithreading, unless the `--no-multithread`command line flag is used

Closes #49 