### PR TITLE
feat(cmd/export) Migrate subcommand to support multithreading

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -2,11 +2,14 @@ package export
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
@@ -58,29 +61,63 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 			}
 
-			// Setup console display
-			disp := display.New(os.Stdout, coreCfg.Hosts, coreCfg.Debug)
-			disp.Start()
-			defer disp.Stop()
-
-			// Iterate over all hosts
-			var lastErr error
-			for i, host := range coreCfg.Hosts {
-				line := disp.Line(i)
-				displayStepCallback := display.NewStepCallback(line)
-				filename, err := export(ctx, host, "", exportCfg, deps, displayStepCallback) // Empty preferred filename = derive automatically
-				if err != nil {
-					line.CompleteStep("❌")
-					line.FinishError(err.Error())
-					lastErr = err
-					// Continue with other hosts even if one fails
-				} else {
-					line.Finish("✅", fmt.Sprintf("Configuration exported to %s", filename))
-				}
-			}
-			return lastErr
+			return runExportForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, exportCfg, deps, os.Stdout)
 		},
 	},
+}
+
+// maxConcurrentHosts limits the number of hosts processed simultaneously in
+// multithread mode to avoid opening too many SSH connections at once.
+const maxConcurrentHosts = 20
+
+func runExportForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, debug)
+	disp.SetConcurrent(!noMultithread)
+	disp.Start()
+	defer disp.Stop()
+
+	// errs is indexed by host position so results are collected in host-list
+	// order regardless of goroutine completion order.
+	errs := make([]error, len(hosts))
+	var wg sync.WaitGroup
+
+	processHost := func(i int, host string) {
+		line := disp.Line(i)
+		displayStepCallback := display.NewStepCallback(line)
+		filename, err := export(ctx, host, "", cfg, deps, displayStepCallback) // Empty preferred filename = derive automatically
+		if err != nil {
+			line.CompleteStep("❌")
+			line.FinishError(err.Error())
+			errs[i] = err
+			return
+		}
+		line.Finish("✅", fmt.Sprintf("Configuration exported to %s", filename))
+	}
+
+	sem := make(chan struct{}, maxConcurrentHosts)
+	var ctxErr error
+loop:
+	for i, host := range hosts {
+		if noMultithread {
+			processHost(i, host)
+		} else {
+			wg.Add(1)
+			select {
+			case sem <- struct{}{}:
+				go func(idx int, h string) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					processHost(idx, h)
+				}(i, host)
+			case <-ctx.Done():
+				wg.Done()
+				ctxErr = ctx.Err()
+				break loop
+			}
+		}
+	}
+	wg.Wait()
+	return errors.Join(append(errs, ctxErr)...)
 }
 
 // Export is a public wrapper that exports configuration for a single host

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
@@ -616,6 +615,12 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 
 	var inFlight atomic.Int32
 	var maxInFlight atomic.Int32
+	nHosts := len(hosts)
+	// allStarted is closed once every goroutine has incremented inFlight,
+	// so maxInFlight is captured while all connections are simultaneously
+	// in-flight without relying on timing or sleep.
+	allStarted := make(chan struct{})
+	var startedCount atomic.Int32
 
 	deps := ExportDependencies{
 		SSHConnectionFactory: func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
@@ -626,11 +631,15 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 					break
 				}
 			}
+			// Barrier: block until every goroutine has reached this point.
+			if startedCount.Add(1) == int32(nHosts) {
+				close(allStarted)
+			} else {
+				<-allStarted
+			}
 
 			return &sshmocks_test.MockRunner{
 				RunFunc: func(cmd string) (string, error) {
-					// Force overlap across goroutines.
-					time.Sleep(20 * time.Millisecond)
 					return "/interface bridge\nadd name=bridge1", nil
 				},
 				CloseFunc: func() error {
@@ -655,7 +664,8 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 			t.Errorf("output missing host %q: %q", host, output)
 		}
 	}
-	if maxInFlight.Load() < 2 {
-		t.Errorf("expected concurrent execution, peak in-flight connections=%d", maxInFlight.Load())
+	if maxInFlight.Load() <= 1 {
+		t.Errorf("expected maxInFlight > 1 (goroutines should run concurrently), got %d", maxInFlight.Load())
 	}
+	t.Logf("peak concurrent SSH connections: %d", maxInFlight.Load())
 }

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -1,13 +1,16 @@
 package export
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
@@ -564,5 +567,95 @@ func TestExport_StepCallbackSequence(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("step callback sequence mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestRunExportForHosts_Sequential(t *testing.T) {
+	hosts := []string{"router-ok", "router-fail"}
+	tmpDir := t.TempDir()
+
+	deps := ExportDependencies{
+		SSHConnectionFactory: func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+			return &sshmocks_test.MockRunner{
+				RunFunc: func(cmd string) (string, error) {
+					if host == "router-fail" {
+						return "", fmt.Errorf("boom")
+					}
+					return "/interface bridge\nadd name=bridge1", nil
+				},
+				CloseFunc: func() error {
+					return nil
+				},
+			}, nil
+		},
+	}
+
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
+
+	var out bytes.Buffer
+	err := runExportForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	if err == nil {
+		t.Fatal("runExportForHosts() expected non-nil error when one host fails")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "router-ok") || !strings.Contains(output, "router-fail") {
+		t.Errorf("output should contain both hosts, got: %q", output)
+	}
+	if !strings.Contains(output, "Configuration exported to router-ok.rsc") {
+		t.Errorf("missing success message, got: %q", output)
+	}
+	if !strings.Contains(output, "failed to export configuration: boom") {
+		t.Errorf("missing failure message, got: %q", output)
+	}
+}
+
+func TestRunExportForHosts_Concurrent(t *testing.T) {
+	hosts := []string{"router-1", "router-2", "router-3"}
+	tmpDir := t.TempDir()
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	deps := ExportDependencies{
+		SSHConnectionFactory: func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+			current := inFlight.Add(1)
+			for {
+				old := maxInFlight.Load()
+				if current <= old || maxInFlight.CompareAndSwap(old, current) {
+					break
+				}
+			}
+
+			return &sshmocks_test.MockRunner{
+				RunFunc: func(cmd string) (string, error) {
+					// Force overlap across goroutines.
+					time.Sleep(20 * time.Millisecond)
+					return "/interface bridge\nadd name=bridge1", nil
+				},
+				CloseFunc: func() error {
+					inFlight.Add(-1)
+					return nil
+				},
+			}, nil
+		},
+	}
+
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
+
+	var out bytes.Buffer
+	err := runExportForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	if err != nil {
+		t.Fatalf("runExportForHosts() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	for _, host := range hosts {
+		if !strings.Contains(output, host) {
+			t.Errorf("output missing host %q: %q", host, output)
+		}
+	}
+	if maxInFlight.Load() < 2 {
+		t.Errorf("expected concurrent execution, peak in-flight connections=%d", maxInFlight.Load())
 	}
 }

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -190,7 +190,7 @@ func TestOutputOrder(t *testing.T) {
 	if idx1 < 0 || idx2 < 0 || idx3 < 0 {
 		t.Fatalf("output missing one or more hostnames: %q", output)
 	}
-	if !(idx1 < idx2 && idx2 < idx3) {
+	if idx1 >= idx2 || idx2 >= idx3 {
 		t.Errorf("output not in host-list order: host1=%d host2=%d host3=%d\n%s",
 			idx1, idx2, idx3, output)
 	}


### PR DESCRIPTION
Enable multithreading for `export` subcommand.

Changes:
* Refactors `cmd/export` to run configuration export concurrently (or sequentially when disabled).
* Adds unit tests covering sequential vs concurrent execution paths.

Closes #49 