### PR TITLE
feat(cmd/enroll) Migrate subcommand to support multithreading

### DIFF
--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -3,10 +3,13 @@ package enroll
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/cmd/export"
@@ -108,33 +111,87 @@ var Command = []*cli.Command{
 				ExportConfigFunc:     export.Export,
 			}
 
-			// Set up live display
-			disp := display.New(os.Stdout, coreCfg.Hosts, coreCfg.Debug)
-			disp.Start()
-			defer disp.Stop()
+			if err := validateEnrollAction(enrollCfg, coreCfg.Hosts); err != nil {
+				return err
+			}
 
-			var lastErr error
-			if len(coreCfg.Hosts) == 0 {
-				slog.Warn("no hosts defined in configuration, nothing to enroll")
-				lastErr = fmt.Errorf("no hosts defined in configuration")
-			}
-			for i, host := range coreCfg.Hosts {
-				line := disp.Line(i)
-				displayStepCallback := display.NewStepCallback(line)
-				if err := enroll(ctx, host, enrollCfg, deps, displayStepCallback); err != nil {
-					line.CompleteStep("❌")
-					line.FinishError(fmt.Sprintf("Enrollment failed: %s", err.Error()))
-					lastErr = err
-					slog.Error("enrollment failed", "host", host, "hostname", enrollCfg.Hostname, "error", err)
-					// Continue with other hosts even if one fails
-				} else {
-					slog.Info("enrollment completed successfully", "host", host, "hostname", enrollCfg.Hostname)
-					line.Finish("✅", "Enrollment completed successfully")
-				}
-			}
-			return lastErr
+			return runEnrollForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, enrollCfg, deps, os.Stdout)
 		},
 	},
+}
+
+// maxConcurrentHosts limits the number of hosts processed simultaneously in
+// multithread mode to avoid opening too many SSH connections at once.
+const maxConcurrentHosts = 20
+
+func validateEnrollAction(cfg EnrollConfig, hosts []string) error {
+	if cfg.Force && cfg.UpdateHostKeyOnly {
+		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
+	}
+	if len(hosts) == 0 {
+		return fmt.Errorf("no hosts specified or discovered")
+	}
+	if cfg.UpdateHostKeyOnly {
+		return nil
+	}
+	if len(hosts) != 1 {
+		return fmt.Errorf("enroll command requires exactly one host, got %d", len(hosts))
+	}
+	if cfg.Hostname == "" {
+		return fmt.Errorf("--hostname is required for enrollment")
+	}
+	return nil
+}
+
+func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, debug)
+	disp.SetConcurrent(!noMultithread)
+	disp.Start()
+	defer disp.Stop()
+
+	// errs is indexed by host position so results are collected in host-list
+	// order regardless of goroutine completion order.
+	errs := make([]error, len(hosts))
+	var wg sync.WaitGroup
+
+	processHost := func(i int, host string) {
+		line := disp.Line(i)
+		displayStepCallback := display.NewStepCallback(line)
+		if err := enroll(ctx, host, cfg, deps, displayStepCallback); err != nil {
+			line.CompleteStep("❌")
+			line.FinishError(fmt.Sprintf("Enrollment failed: %s", err.Error()))
+			errs[i] = err
+			slog.Error("enrollment failed", "host", host, "hostname", cfg.Hostname, "error", err)
+			return
+		}
+		slog.Info("enrollment completed successfully", "host", host, "hostname", cfg.Hostname)
+		line.Finish("✅", "Enrollment completed successfully")
+	}
+
+	sem := make(chan struct{}, maxConcurrentHosts)
+	var ctxErr error
+loop:
+	for i, host := range hosts {
+		if noMultithread {
+			processHost(i, host)
+		} else {
+			wg.Add(1)
+			select {
+			case sem <- struct{}{}:
+				go func(idx int, h string) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					processHost(idx, h)
+				}(i, host)
+			case <-ctx.Done():
+				wg.Done()
+				ctxErr = ctx.Err()
+				break loop
+			}
+		}
+	}
+	wg.Wait()
+	return errors.Join(append(errs, ctxErr)...)
 }
 
 // enroll is the entry point for the enrollment command

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -116,10 +116,6 @@ var Command = []*cli.Command{
 				ExportConfigFunc:     export.Export,
 			}
 
-			if err := validateEnrollAction(enrollCfg, coreCfg.Hosts); err != nil {
-				return err
-			}
-
 			return runEnrollForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, enrollCfg, deps, os.Stdout)
 		},
 	},
@@ -129,26 +125,22 @@ var Command = []*cli.Command{
 // multithread mode to avoid opening too many SSH connections at once.
 const maxConcurrentHosts = 20
 
-func validateEnrollAction(cfg EnrollConfig, hosts []string) error {
+func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
 	if cfg.Force && cfg.UpdateHostKeyOnly {
 		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
 	}
 	if len(hosts) == 0 {
 		return fmt.Errorf("no hosts specified or discovered")
 	}
-	if cfg.UpdateHostKeyOnly {
-		return nil
+	if !cfg.UpdateHostKeyOnly {
+		if len(hosts) != 1 {
+			return fmt.Errorf("enroll command requires exactly one host, got %d", len(hosts))
+		}
+		if cfg.Hostname == "" {
+			return fmt.Errorf("--hostname is required for enrollment")
+		}
 	}
-	if len(hosts) != 1 {
-		return fmt.Errorf("enroll command requires exactly one host, got %d", len(hosts))
-	}
-	if cfg.Hostname == "" {
-		return fmt.Errorf("--hostname is required for enrollment")
-	}
-	return nil
-}
 
-func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, debug)
 	disp.SetConcurrent(!noMultithread)
 	disp.Start()
@@ -212,12 +204,11 @@ func enroll(ctx context.Context, host string, enrollCfg EnrollConfig, deps Enrol
 	ctx = context.WithValue(ctx, core.EnrollmentKey, true)
 	slog.Debug("enrollment mode enabled in context")
 
+	hostname := enrollCfg.Hostname
 	// Validate flag combination
 	if enrollCfg.Force && enrollCfg.UpdateHostKeyOnly {
 		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
 	}
-
-	hostname := enrollCfg.Hostname
 	// Handle force re-enrollment by removing existing artifacts
 	if enrollCfg.Force {
 		slog.Info("force re-enrollment requested", "host", host)

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -205,10 +205,6 @@ func enroll(ctx context.Context, host string, enrollCfg EnrollConfig, deps Enrol
 	slog.Debug("enrollment mode enabled in context")
 
 	hostname := enrollCfg.Hostname
-	// Validate flag combination
-	if enrollCfg.Force && enrollCfg.UpdateHostKeyOnly {
-		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
-	}
 	// Handle force re-enrollment by removing existing artifacts
 	if enrollCfg.Force {
 		slog.Info("force re-enrollment requested", "host", host)

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -38,6 +38,11 @@ type EnrollDependencies struct {
 	ExportConfigFunc     func(context.Context, string, string, bool, string) error
 }
 
+type deleteExistingEnrollmentResult struct {
+	hostKeyDeleted bool
+	configDeleted  string
+}
+
 var Command = []*cli.Command{
 	{
 		Name:  "enroll",
@@ -216,10 +221,23 @@ func enroll(ctx context.Context, host string, enrollCfg EnrollConfig, deps Enrol
 	// Handle force re-enrollment by removing existing artifacts
 	if enrollCfg.Force {
 		slog.Info("force re-enrollment requested", "host", host)
-		if err := deleteExistingEnrollment(host, hostname); err != nil {
+		reportStep("⏳", "Removing existing enrollment artifacts…")
+		cleanupResult, err := deleteExistingEnrollment(host, hostname)
+		if err != nil {
 			slog.Error("failed to remove existing enrollment", "host", host, "hostname", hostname, "error", err)
 			return fmt.Errorf("failed to remove existing enrollment: %w", err)
 		}
+		switch {
+		case cleanupResult.hostKeyDeleted && cleanupResult.configDeleted != "":
+			reportStep("⏳", fmt.Sprintf("Removed existing host key and config file %s", cleanupResult.configDeleted))
+		case cleanupResult.hostKeyDeleted:
+			reportStep("⏳", "Removed existing host key")
+		case cleanupResult.configDeleted != "":
+			reportStep("⏳", fmt.Sprintf("Removed existing config file %s", cleanupResult.configDeleted))
+		default:
+			reportStep("⏳", "No existing enrollment artifacts found")
+		}
+		reportStep("✅", "Removed existing enrollment artifacts")
 	}
 
 	// Check if context is already cancelled
@@ -415,7 +433,6 @@ func applyConfigFile(conn ssh.RunnerInterface, filePath string) error {
 func setRouterIdentity(conn ssh.RunnerInterface, hostname string) error {
 	if hostname == "" {
 		slog.Debug("skipping router identity set, hostname is empty", "hostname", hostname)
-		fmt.Printf("❓ Router identity set skipped. --hostname not provided\n")
 		return nil
 	}
 	cmd := fmt.Sprintf("/system identity set name=%s", hostname)
@@ -479,18 +496,21 @@ func updateHostKey(ctx context.Context, host string, deps EnrollDependencies) (s
 	return newInfo.Fingerprint, nil
 }
 
-// deleteExistingEnrollment removes all enrollment artifacts for a host
-func deleteExistingEnrollment(host string, hostname string) error {
+// deleteExistingEnrollment removes all enrollment artifacts for a host.
+// It returns metadata describing what was removed so the caller can decide
+// how to surface that information through the display system.
+func deleteExistingEnrollment(host string, hostname string) (deleteExistingEnrollmentResult, error) {
 	slog.Info("deleting existing enrollment artifacts", "host", host, "hostname", hostname)
+	result := deleteExistingEnrollmentResult{}
 
 	// Delete host key
 	if ssh.HostKeyExists(host) {
 		slog.Debug("deleting host key", "host", host, "hostname", hostname)
 		if err := ssh.DeleteHostKey(host); err != nil {
 			slog.Error("failed to delete host key", "host", host, "hostname", hostname, "error", err)
-			return fmt.Errorf("failed to delete host key: %w", err)
+			return result, fmt.Errorf("failed to delete host key: %w", err)
 		}
-		fmt.Printf("Removed existing host key for %s\n", host)
+		result.hostKeyDeleted = true
 	}
 
 	// Delete config file
@@ -500,11 +520,11 @@ func deleteExistingEnrollment(host string, hostname string) error {
 		slog.Debug("deleting config file", "host", host, "hostname", hostname, "file", configFile)
 		if err := os.Remove(configFile); err != nil {
 			slog.Error("failed to delete config file", "host", host, "hostname", hostname, "file", configFile, "error", err)
-			return fmt.Errorf("failed to delete config file: %w", err)
+			return result, fmt.Errorf("failed to delete config file: %w", err)
 		}
-		fmt.Printf("Removed existing config file %s\n", configFile)
+		result.configDeleted = configFile
 	}
 
 	slog.Info("existing enrollment artifacts deleted", "host", host, "hostname", hostname)
-	return nil
+	return result, nil
 }

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -686,11 +686,8 @@ func TestEnrollActionValidation(t *testing.T) {
 				ExportConfigFunc:     export.Export,
 			}
 
-			err = validateEnrollAction(enrollCfg, cfg.Hosts)
-			if err == nil && enrollCfg.UpdateHostKeyOnly {
-				var out bytes.Buffer
-				err = runEnrollForHosts(ctx, cfg.Hosts, true, true, enrollCfg, deps, &out)
-			}
+			var out bytes.Buffer
+			err = runEnrollForHosts(ctx, cfg.Hosts, true, true, enrollCfg, deps, &out)
 
 			// Verify error expectation
 			if (err != nil) != tt.wantErr {

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -1,12 +1,14 @@
 package enroll
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -666,44 +668,10 @@ func TestEnrollActionValidation(t *testing.T) {
 				ExportConfigFunc:     export.Export,
 			}
 
-			// Validate flag combinations
-			if enrollCfg.Force && enrollCfg.UpdateHostKeyOnly {
-				err = fmt.Errorf("cannot use --force and --update-hostkey-only together")
-			} else if enrollCfg.UpdateHostKeyOnly {
-				// Batch mode: update hostkeys for all discovered hosts
-				if len(cfg.Hosts) > 1 {
-					successCount := 0
-					failCount := 0
-					var lastErr error
-
-					for _, host := range cfg.Hosts {
-						if _, updateErr := updateHostKey(ctx, host, deps); updateErr != nil {
-							failCount++
-							lastErr = updateErr
-						} else {
-							successCount++
-						}
-					}
-
-					if failCount > 0 && successCount == 0 {
-						err = fmt.Errorf("all host key updates failed")
-					} else if failCount > 0 {
-						err = fmt.Errorf("some host key updates failed: %w", lastErr)
-					}
-				} else if len(cfg.Hosts) == 1 {
-					// Single host mode
-					host := cfg.Hosts[0]
-					_, err = updateHostKey(ctx, host, deps)
-				} else {
-					err = fmt.Errorf("no hosts specified or discovered")
-				}
-			} else {
-				// Normal enrollment validation
-				if len(cfg.Hosts) != 1 {
-					err = fmt.Errorf("enroll command requires exactly one host, got %d", len(cfg.Hosts))
-				} else if enrollCfg.Hostname == "" {
-					err = fmt.Errorf("--hostname is required for enrollment")
-				}
+			err = validateEnrollAction(enrollCfg, cfg.Hosts)
+			if err == nil && enrollCfg.UpdateHostKeyOnly {
+				var out bytes.Buffer
+				err = runEnrollForHosts(ctx, cfg.Hosts, true, true, enrollCfg, deps, &out)
 			}
 
 			// Verify error expectation
@@ -732,6 +700,130 @@ func TestEnrollActionValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunEnrollForHosts_Sequential(t *testing.T) {
+	hosts := []string{"router-ok", "router-fail"}
+	tmpDir := t.TempDir()
+	originalWd, _ := os.Getwd()
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+	_ = os.Chdir(tmpDir)
+
+	deps := EnrollDependencies{
+		SSHConnectionFactory: func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+			if host == "router-fail" {
+				return nil, fmt.Errorf("connection refused")
+			}
+			srcFile := filepath.Join(originalWd, "testdata/hostkeys/router1.hostkey")
+			dstFile := ssh.HostKeyFilePath(host)
+			if err := copyFile(srcFile, dstFile); err != nil {
+				return nil, err
+			}
+			return &sshmocks_test.MockRunner{
+				CloseFunc: func() error { return nil },
+				RunFunc:   func(cmd string) (string, error) { return "", nil },
+			}, nil
+		},
+		ApplyUpdatesFunc: updates.Updates,
+		ExportConfigFunc: export.Export,
+	}
+
+	cfg := EnrollConfig{UpdateHostKeyOnly: true}
+
+	var out bytes.Buffer
+	err := runEnrollForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	if err == nil {
+		t.Fatal("runEnrollForHosts() expected non-nil error when one host fails")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "router-ok") || !strings.Contains(output, "router-fail") {
+		t.Errorf("output should contain both hosts, got: %q", output)
+	}
+	if !strings.Contains(output, "Enrollment completed successfully") {
+		t.Errorf("missing success message, got: %q", output)
+	}
+	if !strings.Contains(output, "Enrollment failed: failed to capture host key: failed to connect to device: connection refused") {
+		t.Errorf("missing failure message, got: %q", output)
+	}
+	if !ssh.HostKeyExists("router-ok") {
+		t.Error("expected host key for router-ok to be created")
+	}
+	if ssh.HostKeyExists("router-fail") {
+		t.Error("did not expect host key for router-fail to be created")
+	}
+}
+
+func TestRunEnrollForHosts_Concurrent(t *testing.T) {
+	hosts := []string{"router-1", "router-2", "router-3"}
+	tmpDir := t.TempDir()
+	originalWd, _ := os.Getwd()
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+	_ = os.Chdir(tmpDir)
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	nHosts := len(hosts)
+	allStarted := make(chan struct{})
+	var startedCount atomic.Int32
+
+	deps := EnrollDependencies{
+		SSHConnectionFactory: func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+			current := inFlight.Add(1)
+			for {
+				old := maxInFlight.Load()
+				if current <= old || maxInFlight.CompareAndSwap(old, current) {
+					break
+				}
+			}
+			if startedCount.Add(1) == int32(nHosts) {
+				close(allStarted)
+			} else {
+				<-allStarted
+			}
+			srcFile := filepath.Join(originalWd, "testdata/hostkeys/router1.hostkey")
+			dstFile := ssh.HostKeyFilePath(host)
+			if err := copyFile(srcFile, dstFile); err != nil {
+				inFlight.Add(-1)
+				return nil, err
+			}
+			return &sshmocks_test.MockRunner{
+				CloseFunc: func() error {
+					inFlight.Add(-1)
+					return nil
+				},
+				RunFunc: func(cmd string) (string, error) { return "", nil },
+			}, nil
+		},
+		ApplyUpdatesFunc: updates.Updates,
+		ExportConfigFunc: export.Export,
+	}
+
+	cfg := EnrollConfig{UpdateHostKeyOnly: true}
+
+	var out bytes.Buffer
+	err := runEnrollForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	if err != nil {
+		t.Fatalf("runEnrollForHosts() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	for _, host := range hosts {
+		if !strings.Contains(output, host) {
+			t.Errorf("output missing host %q: %q", host, output)
+		}
+		if !ssh.HostKeyExists(host) {
+			t.Errorf("expected host key for %s to be created", host)
+		}
+	}
+	if maxInFlight.Load() <= 1 {
+		t.Errorf("expected maxInFlight > 1 (goroutines should run concurrently), got %d", maxInFlight.Load())
+	}
+	t.Logf("peak concurrent SSH connections: %d", maxInFlight.Load())
 }
 
 func TestConnectToRouter(t *testing.T) {

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -2053,19 +2053,6 @@ func TestEnrollWorkflow(t *testing.T) {
 			},
 		},
 		{
-			name:              "error: force and update-host-key-only conflict",
-			host:              "test-router12",
-			hostname:          "test-router12",
-			force:             true,
-			updateHostKeyOnly: true,
-			setupMocks: func(t *testing.T) EnrollDependencies {
-				return EnrollDependencies{}
-			},
-			setupFiles:  func(t *testing.T, hostname string) {},
-			wantErr:     true,
-			errContains: "cannot use --force and --update-hostkey-only together",
-		},
-		{
 			name:     "error: SSH connection failure",
 			host:     "test-router15",
 			hostname: "test-router15",

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -339,6 +339,8 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 		hostname        string
 		setupHostKey    bool
 		setupConfigFile bool
+		wantHostKeyGone bool
+		wantConfigGone  bool
 		wantErr         bool
 		errContains     string
 	}{
@@ -348,6 +350,8 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			hostname:        "router1",
 			setupHostKey:    true,
 			setupConfigFile: true,
+			wantHostKeyGone: true,
+			wantConfigGone:  true,
 			wantErr:         false,
 		},
 		{
@@ -356,6 +360,7 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			hostname:        "router2",
 			setupHostKey:    true,
 			setupConfigFile: false,
+			wantHostKeyGone: true,
 			wantErr:         false,
 		},
 		{
@@ -364,6 +369,7 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			hostname:        "router3",
 			setupHostKey:    false,
 			setupConfigFile: true,
+			wantConfigGone:  true,
 			wantErr:         false,
 		},
 		{
@@ -380,6 +386,8 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			hostname:        "router5",
 			setupHostKey:    true,
 			setupConfigFile: true,
+			wantHostKeyGone: true,
+			wantConfigGone:  true,
 			wantErr:         false,
 		},
 	}
@@ -414,7 +422,7 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			}
 
 			// Execute
-			err := deleteExistingEnrollment(tt.host, tt.hostname)
+			result, err := deleteExistingEnrollment(tt.host, tt.hostname)
 
 			// Verify
 			if (err != nil) != tt.wantErr {
@@ -425,6 +433,16 @@ func TestDeleteExistingEnrollment(t *testing.T) {
 			if tt.wantErr && tt.errContains != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("deleteExistingEnrollment() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+
+			if !tt.wantErr {
+				if result.hostKeyDeleted != tt.wantHostKeyGone {
+					t.Errorf("deleteExistingEnrollment() hostKeyDeleted = %v, want %v", result.hostKeyDeleted, tt.wantHostKeyGone)
+				}
+				gotConfigDeleted := result.configDeleted != ""
+				if gotConfigDeleted != tt.wantConfigGone {
+					t.Errorf("deleteExistingEnrollment() configDeleted = %q, want config deleted = %v", result.configDeleted, tt.wantConfigGone)
 				}
 			}
 
@@ -1593,7 +1611,7 @@ func TestEnrollMainWorkflow(t *testing.T) {
 
 					// Handle force re-enrollment
 					if err == nil && enrollCfg.Force {
-						err = deleteExistingEnrollment(host, host)
+						_, err = deleteExistingEnrollment(host, host)
 						if err != nil {
 							err = fmt.Errorf("failed to remove existing enrollment: %w", err)
 						}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -61,7 +61,9 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 			}
 
-			return runExportForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, exportCfg, deps, os.Stdout)
+			opts := RunExportOptions{Debug: coreCfg.Debug, NoMultithread: coreCfg.NoMultithread}
+
+			return runExportForHosts(ctx, coreCfg.Hosts, opts, exportCfg, deps, os.Stdout)
 		},
 	},
 }
@@ -70,9 +72,16 @@ var Command = []*cli.Command{
 // multithread mode to avoid opening too many SSH connections at once.
 const maxConcurrentHosts = 20
 
-func runExportForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
-	disp := display.New(out, hosts, debug)
-	disp.SetConcurrent(!noMultithread)
+// RunExportOptions groups execution flags for runExportForHosts so call sites
+// remain self-describing and can be extended safely in the future.
+type RunExportOptions struct {
+	Debug         bool
+	NoMultithread bool
+}
+
+func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOptions, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, opts.Debug)
+	disp.SetConcurrent(!opts.NoMultithread)
 	disp.Start()
 	defer disp.Stop()
 
@@ -98,7 +107,7 @@ func runExportForHosts(ctx context.Context, hosts []string, debug, noMultithread
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if noMultithread {
+		if opts.NoMultithread {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -590,9 +590,10 @@ func TestRunExportForHosts_Sequential(t *testing.T) {
 	}
 
 	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
+	opts := RunExportOptions{Debug: true, NoMultithread: true}
 
 	var out bytes.Buffer
-	err := runExportForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runExportForHosts() expected non-nil error when one host fails")
 	}
@@ -651,9 +652,10 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 	}
 
 	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
+	opts := RunExportOptions{Debug: true, NoMultithread: false}
 
 	var out bytes.Buffer
-	err := runExportForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err != nil {
 		t.Fatalf("runExportForHosts() unexpected error: %v", err)
 	}

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -61,8 +61,9 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 				ReconnectDelay:       10 * time.Second,
 			}
+			opts := RunUpdatesOptions{Debug: coreCfg.Debug, NoMultithread: coreCfg.NoMultithread}
 
-			return runUpdatesForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, updatesCfg, deps, os.Stdout)
+			return runUpdatesForHosts(ctx, coreCfg.Hosts, opts, updatesCfg, deps, os.Stdout)
 		},
 	},
 }
@@ -71,9 +72,16 @@ var Command = []*cli.Command{
 // multithread mode to avoid opening too many SSH connections at once.
 const maxConcurrentHosts = 20
 
-func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
-	disp := display.New(out, hosts, debug)
-	disp.SetConcurrent(!noMultithread)
+// RunUpdatesOptions groups execution flags for runUpdatesForHosts so call sites
+// remain self-describing and can be extended safely in the future.
+type RunUpdatesOptions struct {
+	Debug         bool
+	NoMultithread bool
+}
+
+func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOptions, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, opts.Debug)
+	disp.SetConcurrent(!opts.NoMultithread)
 	disp.Start()
 	defer disp.Stop()
 
@@ -107,7 +115,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, debug, noMultithrea
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if noMultithread {
+		if opts.NoMultithread {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -1418,9 +1418,10 @@ func TestRunUpdatesForHosts_Sequential(t *testing.T) {
 	}
 
 	cfg := UpdatesConfig{UpdatesApply: true}
+	opts := RunUpdatesOptions{Debug: true, NoMultithread: true}
 
 	var out bytes.Buffer
-	err := runUpdatesForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
 	}
@@ -1508,9 +1509,10 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 	}
 
 	cfg := UpdatesConfig{UpdatesApply: true}
+	opts := RunUpdatesOptions{Debug: true, NoMultithread: false}
 
 	var out bytes.Buffer
-	err := runUpdatesForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
 	}


### PR DESCRIPTION
Enable multithreading for `enroll` subcommand.

Changes:
* Refactors `cmd/enroll` to process hosts concurrently (bounded by a semaphore) when multithreading is enabled, and sequentially when disabled.
* Aggregates per-host errors deterministically (by host index) and returns them via errors.Join.
* Adds unit tests covering sequential vs concurrent execution paths; minor test assertion simplification in display ordering test.

Closes #49 