### PR TITLE
Rework multithreading implementation for better control

### DIFF
--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -116,16 +116,19 @@ var Command = []*cli.Command{
 				ExportConfigFunc:     export.Export,
 			}
 
-			return runEnrollForHosts(ctx, coreCfg.Hosts, coreCfg.Debug, coreCfg.NoMultithread, enrollCfg, deps, os.Stdout)
+			opts := RunEnrollOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
+
+			return runEnrollForHosts(ctx, coreCfg.Hosts, opts, enrollCfg, deps, os.Stdout)
 		},
 	},
 }
 
-// maxConcurrentHosts limits the number of hosts processed simultaneously in
-// multithread mode to avoid opening too many SSH connections at once.
-const maxConcurrentHosts = 20
+type RunEnrollOptions struct {
+	Debug              bool
+	MaxConcurrentHosts int
+}
 
-func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread bool, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
+func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOptions, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
 	if cfg.Force && cfg.UpdateHostKeyOnly {
 		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
 	}
@@ -141,8 +144,8 @@ func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread
 		}
 	}
 
-	disp := display.New(out, hosts, debug)
-	disp.SetConcurrent(!noMultithread)
+	disp := display.New(out, hosts, opts.Debug)
+	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()
 
@@ -165,11 +168,11 @@ func runEnrollForHosts(ctx context.Context, hosts []string, debug, noMultithread
 		line.Finish("✅", "Enrollment completed successfully")
 	}
 
-	sem := make(chan struct{}, maxConcurrentHosts)
+	sem := make(chan struct{}, opts.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if noMultithread {
+		if opts.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -687,7 +687,8 @@ func TestEnrollActionValidation(t *testing.T) {
 			}
 
 			var out bytes.Buffer
-			err = runEnrollForHosts(ctx, cfg.Hosts, true, true, enrollCfg, deps, &out)
+			opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: 1}
+			err = runEnrollForHosts(ctx, cfg.Hosts, opts, enrollCfg, deps, &out)
 
 			// Verify error expectation
 			if (err != nil) != tt.wantErr {
@@ -748,7 +749,8 @@ func TestRunEnrollForHosts_Sequential(t *testing.T) {
 	cfg := EnrollConfig{UpdateHostKeyOnly: true}
 
 	var out bytes.Buffer
-	err := runEnrollForHosts(context.Background(), hosts, true, true, cfg, deps, &out)
+	opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: 1}
+	err := runEnrollForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runEnrollForHosts() expected non-nil error when one host fails")
 	}
@@ -821,7 +823,8 @@ func TestRunEnrollForHosts_Concurrent(t *testing.T) {
 	cfg := EnrollConfig{UpdateHostKeyOnly: true}
 
 	var out bytes.Buffer
-	err := runEnrollForHosts(context.Background(), hosts, true, false, cfg, deps, &out)
+	opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
+	err := runEnrollForHosts(context.Background(), hosts, opts, cfg, deps, &out)
 	if err != nil {
 		t.Fatalf("runEnrollForHosts() unexpected error: %v", err)
 	}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -61,27 +61,23 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 			}
 
-			opts := RunExportOptions{Debug: coreCfg.Debug, NoMultithread: coreCfg.NoMultithread}
+			opts := RunExportOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
 
 			return runExportForHosts(ctx, coreCfg.Hosts, opts, exportCfg, deps, os.Stdout)
 		},
 	},
 }
 
-// maxConcurrentHosts limits the number of hosts processed simultaneously in
-// multithread mode to avoid opening too many SSH connections at once.
-const maxConcurrentHosts = 20
-
 // RunExportOptions groups execution flags for runExportForHosts so call sites
 // remain self-describing and can be extended safely in the future.
 type RunExportOptions struct {
-	Debug         bool
-	NoMultithread bool
+	Debug              bool
+	MaxConcurrentHosts int
 }
 
 func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOptions, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, opts.Debug)
-	disp.SetConcurrent(!opts.NoMultithread)
+	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()
 
@@ -103,11 +99,11 @@ func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOption
 		line.Finish("✅", fmt.Sprintf("Configuration exported to %s", filename))
 	}
 
-	sem := make(chan struct{}, maxConcurrentHosts)
+	sem := make(chan struct{}, opts.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if opts.NoMultithread {
+		if opts.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -590,7 +590,7 @@ func TestRunExportForHosts_Sequential(t *testing.T) {
 	}
 
 	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
-	opts := RunExportOptions{Debug: true, NoMultithread: true}
+	opts := RunExportOptions{Debug: true, MaxConcurrentHosts: 1}
 
 	var out bytes.Buffer
 	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
@@ -652,7 +652,7 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 	}
 
 	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
-	opts := RunExportOptions{Debug: true, NoMultithread: false}
+	opts := RunExportOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
 
 	var out bytes.Buffer
 	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -61,27 +61,23 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 				ReconnectDelay:       10 * time.Second,
 			}
-			opts := RunUpdatesOptions{Debug: coreCfg.Debug, NoMultithread: coreCfg.NoMultithread}
+			opts := RunUpdatesOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
 
 			return runUpdatesForHosts(ctx, coreCfg.Hosts, opts, updatesCfg, deps, os.Stdout)
 		},
 	},
 }
 
-// maxConcurrentHosts limits the number of hosts processed simultaneously in
-// multithread mode to avoid opening too many SSH connections at once.
-const maxConcurrentHosts = 20
-
 // RunUpdatesOptions groups execution flags for runUpdatesForHosts so call sites
 // remain self-describing and can be extended safely in the future.
 type RunUpdatesOptions struct {
-	Debug         bool
-	NoMultithread bool
+	Debug              bool
+	MaxConcurrentHosts int
 }
 
 func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOptions, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, opts.Debug)
-	disp.SetConcurrent(!opts.NoMultithread)
+	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()
 
@@ -111,11 +107,11 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOpti
 		}
 	}
 
-	sem := make(chan struct{}, maxConcurrentHosts)
+	sem := make(chan struct{}, opts.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if opts.NoMultithread {
+		if opts.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -1418,7 +1418,7 @@ func TestRunUpdatesForHosts_Sequential(t *testing.T) {
 	}
 
 	cfg := UpdatesConfig{UpdatesApply: true}
-	opts := RunUpdatesOptions{Debug: true, NoMultithread: true}
+	opts := RunUpdatesOptions{Debug: true, MaxConcurrentHosts: 1}
 
 	var out bytes.Buffer
 	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)
@@ -1509,7 +1509,7 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 	}
 
 	cfg := UpdatesConfig{UpdatesApply: true}
-	opts := RunUpdatesOptions{Debug: true, NoMultithread: false}
+	opts := RunUpdatesOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
 
 	var out bytes.Buffer
 	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -1,11 +1,34 @@
 package core
 
+import (
+	"fmt"
+	"runtime"
+)
+
 type Config struct {
-	Hosts            []string
-	User             string
-	Debug            bool
-	SkipHostKeyCheck bool
-	NoMultithread    bool
+	Hosts                  []string
+	User                   string
+	Debug                  bool
+	SkipHostKeyCheck       bool
+	MaxConcurrentHosts     int
+	EffectiveMaxConcurrent int
+}
+
+// ResolveMaxConcurrentHosts returns the effective host concurrency cap.
+//
+// Behavior:
+//   - negative values are rejected with an error
+//   - 0 auto-detects using the local CPU count
+//   - 1 forces sequential execution
+//   - 2 and above enables parallel processing with that cap
+func ResolveMaxConcurrentHosts(configuredValue int) (int, error) {
+	if configuredValue < 0 {
+		return 0, fmt.Errorf("--max-concurrent-hosts must be 0 (auto-detect), 1 (sequential), or >= 2")
+	}
+	if configuredValue == 0 {
+		return runtime.NumCPU(), nil
+	}
+	return configuredValue, nil
 }
 
 // GetSkipHostKeyCheck returns the SkipHostKeyCheck flag for host key verification

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -18,7 +18,7 @@ type Config struct {
 //
 // Behavior:
 //   - negative values are rejected with an error
-//   - 0 auto-detects using the local CPU count
+//   - 0 auto-detects using GOMAXPROCS (respects container CPU quotas and GOMAXPROCS env var)
 //   - 1 forces sequential execution
 //   - 2 and above enables parallel processing with that cap
 func ResolveMaxConcurrentHosts(configuredValue int) (int, error) {
@@ -26,7 +26,7 @@ func ResolveMaxConcurrentHosts(configuredValue int) (int, error) {
 		return 0, fmt.Errorf("--max-concurrent-hosts must be 0 (auto-detect), 1 (sequential), or >= 2")
 	}
 	if configuredValue == 0 {
-		return runtime.NumCPU(), nil
+		return runtime.GOMAXPROCS(0), nil
 	}
 	return configuredValue, nil
 }

--- a/common/core/config_test.go
+++ b/common/core/config_test.go
@@ -58,9 +58,9 @@ func TestResolveMaxConcurrentHosts(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name:            "zero auto-detects cpu count",
+			name:            "zero auto-detects max procs",
 			configuredValue: 0,
-			want:            runtime.NumCPU(),
+			want:            runtime.GOMAXPROCS(0),
 		},
 		{
 			name:            "one forces sequential",

--- a/common/core/config_test.go
+++ b/common/core/config_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestConfig_GetSkipHostKeyCheck(t *testing.T) {
 	tests := []struct {
@@ -42,6 +45,48 @@ func TestConfig_GetSkipHostKeyCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.config.GetSkipHostKeyCheck(); got != tt.want {
 				t.Errorf("Config.GetSkipHostKeyCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMaxConcurrentHosts(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredValue int
+		want            int
+		wantErr         bool
+	}{
+		{
+			name:            "zero auto-detects cpu count",
+			configuredValue: 0,
+			want:            runtime.NumCPU(),
+		},
+		{
+			name:            "one forces sequential",
+			configuredValue: 1,
+			want:            1,
+		},
+		{
+			name:            "explicit parallel cap accepted",
+			configuredValue: 6,
+			want:            6,
+		},
+		{
+			name:            "negative value rejected",
+			configuredValue: -1,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMaxConcurrentHosts(tt.configuredValue)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveMaxConcurrentHosts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ResolveMaxConcurrentHosts() = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -194,9 +194,12 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 }
 
 // SetConcurrent marks the display as serving concurrent host processing.
-// Must be called before Start. In concurrent non-live mode, HostLine.Finish
-// buffers each line and LiveDisplay.Stop flushes them in host-list order so
-// that output is deterministic regardless of goroutine completion order.
+// Must be called before Start. In concurrent mode the display always uses
+// non-live buffered output — even on a real TTY — so that goroutines finishing
+// at arbitrary times produce clean, deterministic one-line-per-host output
+// flushed in host-list order by Stop. Using liveterm with concurrent goroutines
+// causes intermediate step renders to appear in the scrollback, which is why
+// this path unconditionally disables live mode.
 // In the default sequential mode, Finish writes each line immediately so the
 // caller sees per-host progress in real time.
 func (d *LiveDisplay) SetConcurrent(concurrent bool) {
@@ -205,10 +208,15 @@ func (d *LiveDisplay) SetConcurrent(concurrent bool) {
 		d.clearNonLive()
 		return
 	}
-	// If we are already in non-live mode (e.g. debug=true) and switching to
-	// concurrent, initialise the pending buffer now so that HostLine.Finish
-	// can start buffering without waiting for Start to be called.
-	if !d.liveMode && d.pendingLines == nil {
+	// Concurrent mode always uses non-live buffered output regardless of TTY.
+	// Force liveMode off before Start is called so liveterm is never started.
+	if d.liveMode {
+		d.liveMode = false
+		for _, l := range d.lines {
+			l.liveMode = false
+		}
+	}
+	if d.pendingLines == nil {
 		d.initNonLive()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -102,10 +102,10 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			slog.Info("Starting global")
 
 			effectiveMaxConcurrent, err := core.ResolveMaxConcurrentHosts(globalConfig.MaxConcurrentHosts)
-			slog.Debug("resolved max concurrent hosts", "configured", globalConfig.MaxConcurrentHosts, "effective", effectiveMaxConcurrent)
 			if err != nil {
 				return ctx, err
 			}
+			slog.Debug("resolved max concurrent hosts", "configured", globalConfig.MaxConcurrentHosts, "effective", effectiveMaxConcurrent)
 			globalConfig.EffectiveMaxConcurrent = effectiveMaxConcurrent
 
 			// Check if a subcommand was provided

--- a/main.go
+++ b/main.go
@@ -85,11 +85,11 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Usage:       "Enable debug logging",
 				Destination: &globalConfig.Debug,
 			},
-			&cli.BoolFlag{
-				Name:        "no-multithread",
-				Value:       false,
-				Usage:       "Disable parallel host processing (sequential fallback)",
-				Destination: &globalConfig.NoMultithread,
+			&cli.IntFlag{
+				Name:        "max-concurrent-hosts",
+				Value:       0,
+				Usage:       "Maximum number of hosts to process in parallel (0 = auto-detect, 1 = sequential, >=2 = parallel with that cap)",
+				Destination: &globalConfig.MaxConcurrentHosts,
 			},
 		},
 		Commands: append(append(export.Command, updates.Command...), enroll.Command...),
@@ -101,10 +101,17 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			}
 			slog.Info("Starting global")
 
+			effectiveMaxConcurrent, err := core.ResolveMaxConcurrentHosts(globalConfig.MaxConcurrentHosts)
+			slog.Debug("resolved max concurrent hosts", "configured", globalConfig.MaxConcurrentHosts, "effective", effectiveMaxConcurrent)
+			if err != nil {
+				return ctx, err
+			}
+			globalConfig.EffectiveMaxConcurrent = effectiveMaxConcurrent
+
 			// Check if a subcommand was provided
 			// If not, the help will be shown automatically by urfave/cli
 			if cmd.Args().Len() > 0 {
-				slog.Debug("cmd args", "args", cmd.Args())
+				slog.Debug("command line arguments", "args", cmd.Args())
 				// Setup hosts
 				if *hosts != "" {
 					// Split comma-separated hosts

--- a/main_test.go
+++ b/main_test.go
@@ -521,8 +521,11 @@ func TestBuildCommandMaxConcurrentHostsFlag(t *testing.T) {
 
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
-	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
-	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
+	// Use a pre-cancelled context so the root Before hook fires (binding flags into
+	// globalConfig) but the subcommand action exits immediately without SSH work.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
 	if globalConfig.MaxConcurrentHosts != 4 {
 		t.Errorf("MaxConcurrentHosts = %d, want 4", globalConfig.MaxConcurrentHosts)
 	}
@@ -536,8 +539,11 @@ func TestBuildCommandMaxConcurrentHostsAutoDetect(t *testing.T) {
 	var hosts, sshPassword, sshPassphrase string
 
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
-	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
-	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
+	// Use a pre-cancelled context so the root Before hook fires (binding flags into
+	// globalConfig) but the subcommand action exits immediately without SSH work.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
 	if globalConfig.EffectiveMaxConcurrent != runtime.NumCPU() {
 		t.Errorf("EffectiveMaxConcurrent = %d, want %d", globalConfig.EffectiveMaxConcurrent, runtime.NumCPU())
 	}
@@ -564,8 +570,11 @@ func TestBuildCommandMaxConcurrentHostsSequential(t *testing.T) {
 
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
-	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
-	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
+	// Use a pre-cancelled context so the root Before hook fires (binding flags into
+	// globalConfig) but the subcommand action exits immediately without SSH work.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
 	if globalConfig.EffectiveMaxConcurrent != 1 {
 		t.Errorf("EffectiveMaxConcurrent = %d, want 1", globalConfig.EffectiveMaxConcurrent)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -553,8 +553,9 @@ func TestBuildCommandMaxConcurrentHostsAutoDetect(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
 	}
-	if globalConfig.EffectiveMaxConcurrent != runtime.NumCPU() {
-		t.Errorf("EffectiveMaxConcurrent = %d, want %d", globalConfig.EffectiveMaxConcurrent, runtime.NumCPU())
+	expectedMaxConcurrent := runtime.GOMAXPROCS(0)
+	if globalConfig.EffectiveMaxConcurrent != expectedMaxConcurrent {
+		t.Errorf("EffectiveMaxConcurrent = %d, want %d", globalConfig.EffectiveMaxConcurrent, expectedMaxConcurrent)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -524,6 +524,7 @@ func TestBuildCommandMaxConcurrentHostsFlag(t *testing.T) {
 	// Use a pre-cancelled context so the root Before hook fires (binding flags into
 	// globalConfig) but the subcommand action exits immediately without SSH work.
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	cancel()
 	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
 	if globalConfig.MaxConcurrentHosts != 4 {
@@ -542,6 +543,7 @@ func TestBuildCommandMaxConcurrentHostsAutoDetect(t *testing.T) {
 	// Use a pre-cancelled context so the root Before hook fires (binding flags into
 	// globalConfig) but the subcommand action exits immediately without SSH work.
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	cancel()
 	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
 	if globalConfig.EffectiveMaxConcurrent != runtime.NumCPU() {
@@ -573,6 +575,7 @@ func TestBuildCommandMaxConcurrentHostsSequential(t *testing.T) {
 	// Use a pre-cancelled context so the root Before hook fires (binding flags into
 	// globalConfig) but the subcommand action exits immediately without SSH work.
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	cancel()
 	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
 	if globalConfig.EffectiveMaxConcurrent != 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"runtime"
@@ -526,7 +527,10 @@ func TestBuildCommandMaxConcurrentHostsFlag(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cancel()
-	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
+	}
 	if globalConfig.MaxConcurrentHosts != 4 {
 		t.Errorf("MaxConcurrentHosts = %d, want 4", globalConfig.MaxConcurrentHosts)
 	}
@@ -545,7 +549,10 @@ func TestBuildCommandMaxConcurrentHostsAutoDetect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cancel()
-	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
+	}
 	if globalConfig.EffectiveMaxConcurrent != runtime.NumCPU() {
 		t.Errorf("EffectiveMaxConcurrent = %d, want %d", globalConfig.EffectiveMaxConcurrent, runtime.NumCPU())
 	}
@@ -577,7 +584,10 @@ func TestBuildCommandMaxConcurrentHostsSequential(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cancel()
-	_ = cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
+	}
 	if globalConfig.EffectiveMaxConcurrent != 1 {
 		t.Errorf("EffectiveMaxConcurrent = %d, want 1", globalConfig.EffectiveMaxConcurrent)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
@@ -47,13 +49,13 @@ func TestBuildCommandFlags(t *testing.T) {
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
 	expectedFlags := map[string]bool{
-		"host":               false,
-		"ssh-user":           false,
-		"ssh-password":       false,
-		"ssh-passphrase":     false,
-		"debug":              false,
-		"no-multithread":     false,
-		"skip-hostkey-check": false,
+		"host":                 false,
+		"ssh-user":             false,
+		"ssh-password":         false,
+		"ssh-passphrase":       false,
+		"debug":                false,
+		"max-concurrent-hosts": false,
+		"skip-hostkey-check":   false,
 	}
 
 	// Check all expected flags exist
@@ -510,5 +512,61 @@ func TestBuildCommandDebugFlag(t *testing.T) {
 
 	if globalConfig.Debug {
 		t.Error("Debug flag should be false")
+	}
+}
+
+func TestBuildCommandMaxConcurrentHostsFlag(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
+	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "4", "updates"})
+	if globalConfig.MaxConcurrentHosts != 4 {
+		t.Errorf("MaxConcurrentHosts = %d, want 4", globalConfig.MaxConcurrentHosts)
+	}
+	if globalConfig.EffectiveMaxConcurrent != 4 {
+		t.Errorf("EffectiveMaxConcurrent = %d, want 4", globalConfig.EffectiveMaxConcurrent)
+	}
+}
+
+func TestBuildCommandMaxConcurrentHostsAutoDetect(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
+	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
+	if globalConfig.EffectiveMaxConcurrent != runtime.NumCPU() {
+		t.Errorf("EffectiveMaxConcurrent = %d, want %d", globalConfig.EffectiveMaxConcurrent, runtime.NumCPU())
+	}
+}
+
+func TestBuildCommandMaxConcurrentHostsRejectsInvalidOverride(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	// The Before hook must abort with an error before the subcommand action runs.
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "-1", "updates"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected an error for negative max concurrency")
+	}
+	if !strings.Contains(err.Error(), "--max-concurrent-hosts must be") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildCommandMaxConcurrentHostsSequential(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	// Run with a real subcommand so the root Before hook fires; SSH failure is expected.
+	_ = cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--max-concurrent-hosts", "1", "updates"})
+	if globalConfig.EffectiveMaxConcurrent != 1 {
+		t.Errorf("EffectiveMaxConcurrent = %d, want 1", globalConfig.EffectiveMaxConcurrent)
 	}
 }


### PR DESCRIPTION
Enhance the multithreading capabilities by introducing a configurable maximum number of concurrent hosts. This change allows for more granular control over parallel processing, replacing the previous boolean flag for multithreading. Adjustments made to related functions and tests ensure compatibility with the new implementation.

Closes #50 