### PR TITLE
 feat(*) restore default live display by default while keeping the ability to control it with a new `--buffered-output` command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Available for all commands:
 - `--ssh-password <password>`, `-p <password>` - MikroTik router SSH password
 - `--ssh-passphrase <passphrase>`, `-P <passphrase>` - User private SSH key passphrase
 - `--debug` - Enable debug logging
+- `--buffered-output` - Force buffered host progress output with deterministic final flush (default prefers live output on TTY)
 
 **Example:**
 ```bash

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -31,7 +31,7 @@ type EnrollConfig struct {
 	UpdateHostKeyOnly  bool
 	Debug              bool
 	MaxConcurrentHosts int
-	DisplayMode        display.Mode
+	PreferLiveMode     bool
 }
 
 // EnrollDependencies holds injectable dependencies for testing
@@ -100,11 +100,6 @@ var Command = []*cli.Command{
 				return err
 			}
 
-			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
-			if err != nil {
-				return err
-			}
-
 			// Build enrollment configuration from CLI flags
 			enrollCfg := EnrollConfig{
 				Hostname:           cmd.String("hostname"),
@@ -117,7 +112,7 @@ var Command = []*cli.Command{
 				UpdateHostKeyOnly:  cmd.Bool("update-hostkey-only"),
 				Debug:              coreCfg.Debug,
 				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
+				PreferLiveMode:     coreCfg.PreferLiveMode,
 			}
 
 			// Build dependencies for all operations
@@ -149,9 +144,9 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 	}
 
 	disp := display.New(out, hosts, display.InitOptions{
-		Debug:      cfg.Debug,
-		Mode:       cfg.DisplayMode,
-		Concurrent: cfg.MaxConcurrentHosts > 1,
+		Debug:          cfg.Debug,
+		PreferLiveMode: cfg.PreferLiveMode,
+		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
 	defer disp.Stop()
 

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -148,7 +148,12 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-	defer disp.Stop()
+
+	logLevel := slog.LevelWarn
+	if cfg.Debug {
+		logLevel = slog.LevelDebug
+	}
+	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -192,7 +197,10 @@ loop:
 		}
 	}
 	wg.Wait()
-	return errors.Join(append(errs, ctxErr)...)
+	result := errors.Join(append(errs, ctxErr)...)
+	disp.Stop()
+	restoreLogger()
+	return result
 }
 
 // enroll is the entry point for the enrollment command

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -148,12 +148,7 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-
-	logLevel := slog.LevelWarn
-	if cfg.Debug {
-		logLevel = slog.LevelDebug
-	}
-	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
+	core.SetLiveLogWriter(disp.LogWriter())
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -199,7 +194,7 @@ loop:
 	wg.Wait()
 	result := errors.Join(append(errs, ctxErr)...)
 	disp.Stop()
-	restoreLogger()
+	core.SetLiveLogWriter(nil)
 	return result
 }
 

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -97,6 +97,11 @@ var Command = []*cli.Command{
 				return err
 			}
 
+			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
+			if err != nil {
+				return err
+			}
+
 			// Build enrollment configuration from CLI flags
 			enrollCfg := EnrollConfig{
 				Hostname:          cmd.String("hostname"),
@@ -116,7 +121,11 @@ var Command = []*cli.Command{
 				ExportConfigFunc:     export.Export,
 			}
 
-			opts := RunEnrollOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
+			opts := RunEnrollOptions{
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
+			}
 
 			return runEnrollForHosts(ctx, coreCfg.Hosts, opts, enrollCfg, deps, os.Stdout)
 		},
@@ -126,6 +135,7 @@ var Command = []*cli.Command{
 type RunEnrollOptions struct {
 	Debug              bool
 	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOptions, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
@@ -145,6 +155,7 @@ func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOption
 	}
 
 	disp := display.New(out, hosts, opts.Debug)
+	disp.SetMode(opts.DisplayMode)
 	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -21,14 +21,17 @@ import (
 
 // EnrollConfig holds all enrollment configuration options
 type EnrollConfig struct {
-	Hostname          string
-	PreEnrollScript   string
-	PostEnrollScript  string
-	SkipUpdates       bool
-	SkipExport        bool
-	OutputDir         string
-	Force             bool
-	UpdateHostKeyOnly bool
+	Hostname           string
+	PreEnrollScript    string
+	PostEnrollScript   string
+	SkipUpdates        bool
+	SkipExport         bool
+	OutputDir          string
+	Force              bool
+	UpdateHostKeyOnly  bool
+	Debug              bool
+	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 // EnrollDependencies holds injectable dependencies for testing
@@ -104,14 +107,17 @@ var Command = []*cli.Command{
 
 			// Build enrollment configuration from CLI flags
 			enrollCfg := EnrollConfig{
-				Hostname:          cmd.String("hostname"),
-				PreEnrollScript:   cmd.String("pre-enroll-script"),
-				PostEnrollScript:  cmd.String("post-enroll-script"),
-				SkipUpdates:       cmd.Bool("skip-updates"),
-				SkipExport:        cmd.Bool("skip-export"),
-				OutputDir:         cmd.String("output-dir"),
-				Force:             cmd.Bool("force"),
-				UpdateHostKeyOnly: cmd.Bool("update-hostkey-only"),
+				Hostname:           cmd.String("hostname"),
+				PreEnrollScript:    cmd.String("pre-enroll-script"),
+				PostEnrollScript:   cmd.String("post-enroll-script"),
+				SkipUpdates:        cmd.Bool("skip-updates"),
+				SkipExport:         cmd.Bool("skip-export"),
+				OutputDir:          cmd.String("output-dir"),
+				Force:              cmd.Bool("force"),
+				UpdateHostKeyOnly:  cmd.Bool("update-hostkey-only"),
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
 			}
 
 			// Build dependencies for all operations
@@ -121,24 +127,12 @@ var Command = []*cli.Command{
 				ExportConfigFunc:     export.Export,
 			}
 
-			opts := RunEnrollOptions{
-				Debug:              coreCfg.Debug,
-				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
-			}
-
-			return runEnrollForHosts(ctx, coreCfg.Hosts, opts, enrollCfg, deps, os.Stdout)
+			return runEnrollForHosts(ctx, coreCfg.Hosts, enrollCfg, deps, os.Stdout)
 		},
 	},
 }
 
-type RunEnrollOptions struct {
-	Debug              bool
-	MaxConcurrentHosts int
-	DisplayMode        display.Mode
-}
-
-func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOptions, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
+func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, deps EnrollDependencies, out io.Writer) error {
 	if cfg.Force && cfg.UpdateHostKeyOnly {
 		return fmt.Errorf("cannot use --force and --update-hostkey-only together")
 	}
@@ -154,10 +148,11 @@ func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOption
 		}
 	}
 
-	disp := display.New(out, hosts, opts.Debug)
-	disp.SetMode(opts.DisplayMode)
-	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
-	disp.Start()
+	disp := display.New(out, hosts, display.InitOptions{
+		Debug:      cfg.Debug,
+		Mode:       cfg.DisplayMode,
+		Concurrent: cfg.MaxConcurrentHosts > 1,
+	})
 	defer disp.Stop()
 
 	// errs is indexed by host position so results are collected in host-list
@@ -179,11 +174,11 @@ func runEnrollForHosts(ctx context.Context, hosts []string, opts RunEnrollOption
 		line.Finish("✅", "Enrollment completed successfully")
 	}
 
-	sem := make(chan struct{}, opts.MaxConcurrentHosts)
+	sem := make(chan struct{}, cfg.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if opts.MaxConcurrentHosts <= 1 {
+		if cfg.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -15,6 +15,7 @@ import (
 	"jb.favre/mikrotik-fleet-autopilot/cmd/export"
 	"jb.favre/mikrotik-fleet-autopilot/cmd/updates"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
+	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -687,8 +688,10 @@ func TestEnrollActionValidation(t *testing.T) {
 			}
 
 			var out bytes.Buffer
-			opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: 1}
-			err = runEnrollForHosts(ctx, cfg.Hosts, opts, enrollCfg, deps, &out)
+			enrollCfg.Debug = true
+			enrollCfg.MaxConcurrentHosts = 1
+			enrollCfg.DisplayMode = display.ModeAuto
+			err = runEnrollForHosts(ctx, cfg.Hosts, enrollCfg, deps, &out)
 
 			// Verify error expectation
 			if (err != nil) != tt.wantErr {
@@ -746,11 +749,10 @@ func TestRunEnrollForHosts_Sequential(t *testing.T) {
 		ExportConfigFunc: export.Export,
 	}
 
-	cfg := EnrollConfig{UpdateHostKeyOnly: true}
+	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: 1}
-	err := runEnrollForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runEnrollForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runEnrollForHosts() expected non-nil error when one host fails")
 	}
@@ -820,11 +822,10 @@ func TestRunEnrollForHosts_Concurrent(t *testing.T) {
 		ExportConfigFunc: export.Export,
 	}
 
-	cfg := EnrollConfig{UpdateHostKeyOnly: true}
+	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	opts := RunEnrollOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
-	err := runEnrollForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runEnrollForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err != nil {
 		t.Fatalf("runEnrollForHosts() unexpected error: %v", err)
 	}

--- a/cmd/enroll/enroll_test.go
+++ b/cmd/enroll/enroll_test.go
@@ -15,7 +15,6 @@ import (
 	"jb.favre/mikrotik-fleet-autopilot/cmd/export"
 	"jb.favre/mikrotik-fleet-autopilot/cmd/updates"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
-	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -690,7 +689,7 @@ func TestEnrollActionValidation(t *testing.T) {
 			var out bytes.Buffer
 			enrollCfg.Debug = true
 			enrollCfg.MaxConcurrentHosts = 1
-			enrollCfg.DisplayMode = display.ModeAuto
+			enrollCfg.PreferLiveMode = true
 			err = runEnrollForHosts(ctx, cfg.Hosts, enrollCfg, deps, &out)
 
 			// Verify error expectation
@@ -749,7 +748,7 @@ func TestRunEnrollForHosts_Sequential(t *testing.T) {
 		ExportConfigFunc: export.Export,
 	}
 
-	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
+	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: 1, PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runEnrollForHosts(context.Background(), hosts, cfg, deps, &out)
@@ -822,7 +821,7 @@ func TestRunEnrollForHosts_Concurrent(t *testing.T) {
 		ExportConfigFunc: export.Export,
 	}
 
-	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
+	cfg := EnrollConfig{UpdateHostKeyOnly: true, Debug: true, MaxConcurrentHosts: len(hosts), PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runEnrollForHosts(context.Background(), hosts, cfg, deps, &out)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -51,6 +51,11 @@ var Command = []*cli.Command{
 				return err
 			}
 
+			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
+			if err != nil {
+				return err
+			}
+
 			// Build export configuration from CLI flags
 			exportCfg := ExportConfig{
 				ShowSensitive: cmd.Bool("show-sensitive"),
@@ -61,7 +66,11 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 			}
 
-			opts := RunExportOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
+			opts := RunExportOptions{
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
+			}
 
 			return runExportForHosts(ctx, coreCfg.Hosts, opts, exportCfg, deps, os.Stdout)
 		},
@@ -73,10 +82,12 @@ var Command = []*cli.Command{
 type RunExportOptions struct {
 	Debug              bool
 	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOptions, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, opts.Debug)
+	disp.SetMode(opts.DisplayMode)
 	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -19,8 +19,11 @@ import (
 
 // ExportConfig holds all export configuration options
 type ExportConfig struct {
-	ShowSensitive bool
-	OutputDir     string
+	ShowSensitive      bool
+	OutputDir          string
+	Debug              bool
+	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 // ExportDependencies holds injectable dependencies for testing
@@ -58,38 +61,28 @@ var Command = []*cli.Command{
 
 			// Build export configuration from CLI flags
 			exportCfg := ExportConfig{
-				ShowSensitive: cmd.Bool("show-sensitive"),
-				OutputDir:     cmd.String("output-dir"),
+				ShowSensitive:      cmd.Bool("show-sensitive"),
+				OutputDir:          cmd.String("output-dir"),
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
 			}
 
 			deps := ExportDependencies{
 				SSHConnectionFactory: ssh.CreateConnection,
 			}
 
-			opts := RunExportOptions{
-				Debug:              coreCfg.Debug,
-				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
-			}
-
-			return runExportForHosts(ctx, coreCfg.Hosts, opts, exportCfg, deps, os.Stdout)
+			return runExportForHosts(ctx, coreCfg.Hosts, exportCfg, deps, os.Stdout)
 		},
 	},
 }
 
-// RunExportOptions groups execution flags for runExportForHosts so call sites
-// remain self-describing and can be extended safely in the future.
-type RunExportOptions struct {
-	Debug              bool
-	MaxConcurrentHosts int
-	DisplayMode        display.Mode
-}
-
-func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOptions, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
-	disp := display.New(out, hosts, opts.Debug)
-	disp.SetMode(opts.DisplayMode)
-	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
-	disp.Start()
+func runExportForHosts(ctx context.Context, hosts []string, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, display.InitOptions{
+		Debug:      cfg.Debug,
+		Mode:       cfg.DisplayMode,
+		Concurrent: cfg.MaxConcurrentHosts > 1,
+	})
 	defer disp.Stop()
 
 	// errs is indexed by host position so results are collected in host-list
@@ -114,11 +107,11 @@ func runExportForHosts(ctx context.Context, hosts []string, opts RunExportOption
 		}
 	}
 
-	sem := make(chan struct{}, opts.MaxConcurrentHosts)
+	sem := make(chan struct{}, cfg.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if opts.MaxConcurrentHosts <= 1 {
+		if cfg.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -78,12 +78,7 @@ func runExportForHosts(ctx context.Context, hosts []string, cfg ExportConfig, de
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-
-	logLevel := slog.LevelWarn
-	if cfg.Debug {
-		logLevel = slog.LevelDebug
-	}
-	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
+	core.SetLiveLogWriter(disp.LogWriter())
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -132,7 +127,7 @@ loop:
 	wg.Wait()
 	result := errors.Join(append(errs, ctxErr)...)
 	disp.Stop()
-	restoreLogger()
+	core.SetLiveLogWriter(nil)
 	return result
 }
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -78,7 +78,12 @@ func runExportForHosts(ctx context.Context, hosts []string, cfg ExportConfig, de
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-	defer disp.Stop()
+
+	logLevel := slog.LevelWarn
+	if cfg.Debug {
+		logLevel = slog.LevelDebug
+	}
+	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -125,7 +130,10 @@ loop:
 		}
 	}
 	wg.Wait()
-	return errors.Join(append(errs, ctxErr)...)
+	result := errors.Join(append(errs, ctxErr)...)
+	disp.Stop()
+	restoreLogger()
+	return result
 }
 
 // Export is a public wrapper that exports configuration for a single host

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -23,7 +23,7 @@ type ExportConfig struct {
 	OutputDir          string
 	Debug              bool
 	MaxConcurrentHosts int
-	DisplayMode        display.Mode
+	PreferLiveMode     bool
 }
 
 // ExportDependencies holds injectable dependencies for testing
@@ -54,18 +54,13 @@ var Command = []*cli.Command{
 				return err
 			}
 
-			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
-			if err != nil {
-				return err
-			}
-
 			// Build export configuration from CLI flags
 			exportCfg := ExportConfig{
 				ShowSensitive:      cmd.Bool("show-sensitive"),
 				OutputDir:          cmd.String("output-dir"),
 				Debug:              coreCfg.Debug,
 				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
+				PreferLiveMode:     coreCfg.PreferLiveMode,
 			}
 
 			deps := ExportDependencies{
@@ -79,9 +74,9 @@ var Command = []*cli.Command{
 
 func runExportForHosts(ctx context.Context, hosts []string, cfg ExportConfig, deps ExportDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, display.InitOptions{
-		Debug:      cfg.Debug,
-		Mode:       cfg.DisplayMode,
-		Concurrent: cfg.MaxConcurrentHosts > 1,
+		Debug:          cfg.Debug,
+		PreferLiveMode: cfg.PreferLiveMode,
+		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
 	defer disp.Stop()
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
+	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -590,11 +591,10 @@ func TestRunExportForHosts_Sequential(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
-	opts := RunExportOptions{Debug: true, MaxConcurrentHosts: 1}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runExportForHosts() expected non-nil error when one host fails")
 	}
@@ -652,11 +652,10 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
-	opts := RunExportOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err != nil {
 		t.Fatalf("runExportForHosts() unexpected error: %v", err)
 	}
@@ -693,11 +692,10 @@ func TestRunExportForHosts_ConnectionFailureNonFatal(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir}
-	opts := RunExportOptions{Debug: true, MaxConcurrentHosts: 1}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	err := runExportForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err != nil {
 		t.Fatalf("runExportForHosts() expected nil error for connection failure, got: %v", err)
 	}

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
-	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -591,7 +590,7 @@ func TestRunExportForHosts_Sequential(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)
@@ -652,7 +651,7 @@ func TestRunExportForHosts_Concurrent(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: len(hosts), PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)
@@ -692,7 +691,7 @@ func TestRunExportForHosts_ConnectionFailureNonFatal(t *testing.T) {
 		},
 	}
 
-	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
+	cfg := ExportConfig{ShowSensitive: false, OutputDir: tmpDir, Debug: true, MaxConcurrentHosts: 1, PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runExportForHosts(context.Background(), hosts, cfg, deps, &out)

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -79,12 +79,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, 
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-
-	logLevel := slog.LevelWarn
-	if cfg.Debug {
-		logLevel = slog.LevelDebug
-	}
-	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
+	core.SetLiveLogWriter(disp.LogWriter())
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -136,7 +131,7 @@ loop:
 	wg.Wait()
 	result := errors.Join(append(errs, ctxErr)...)
 	disp.Stop()
-	restoreLogger()
+	core.SetLiveLogWriter(nil)
 	return result
 }
 

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hekmon/liveterm/v2"
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/display"
@@ -79,7 +80,20 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, 
 		PreferLiveMode: cfg.PreferLiveMode,
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
-	defer disp.Stop()
+
+	var restoreLogger func()
+	if disp.LiveMode() {
+		previousLogger := slog.Default()
+		logLevel := slog.LevelWarn
+		if cfg.Debug {
+			logLevel = slog.LevelDebug
+		}
+		handler := slog.NewTextHandler(liveterm.Bypass(), &slog.HandlerOptions{Level: logLevel})
+		slog.SetDefault(slog.New(handler))
+		restoreLogger = func() {
+			slog.SetDefault(previousLogger)
+		}
+	}
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -129,7 +143,12 @@ loop:
 		}
 	}
 	wg.Wait()
-	return errors.Join(append(errs, ctxErr)...)
+	result := errors.Join(append(errs, ctxErr)...)
+	disp.Stop()
+	if restoreLogger != nil {
+		restoreLogger()
+	}
+	return result
 }
 
 type UpdateStatus struct {

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -19,7 +19,10 @@ import (
 
 // UpdatesConfig holds all updates configuration options
 type UpdatesConfig struct {
-	UpdatesApply bool
+	UpdatesApply       bool
+	Debug              bool
+	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 // ErrCannotCheckUpdates is returned when the update status cannot be determined,
@@ -58,7 +61,10 @@ var Command = []*cli.Command{
 
 			// Build updates configuration from CLI flags
 			updatesCfg := UpdatesConfig{
-				UpdatesApply: cmd.Bool("updates-apply"),
+				UpdatesApply:       cmd.Bool("updates-apply"),
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
 			}
 
 			// Build dependencies
@@ -66,30 +72,18 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 				ReconnectDelay:       10 * time.Second,
 			}
-			opts := RunUpdatesOptions{
-				Debug:              coreCfg.Debug,
-				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
-			}
 
-			return runUpdatesForHosts(ctx, coreCfg.Hosts, opts, updatesCfg, deps, os.Stdout)
+			return runUpdatesForHosts(ctx, coreCfg.Hosts, updatesCfg, deps, os.Stdout)
 		},
 	},
 }
 
-// RunUpdatesOptions groups execution flags for runUpdatesForHosts so call sites
-// remain self-describing and can be extended safely in the future.
-type RunUpdatesOptions struct {
-	Debug              bool
-	MaxConcurrentHosts int
-	DisplayMode        display.Mode
-}
-
-func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOptions, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
-	disp := display.New(out, hosts, opts.Debug)
-	disp.SetMode(opts.DisplayMode)
-	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
-	disp.Start()
+func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
+	disp := display.New(out, hosts, display.InitOptions{
+		Debug:      cfg.Debug,
+		Mode:       cfg.DisplayMode,
+		Concurrent: cfg.MaxConcurrentHosts > 1,
+	})
 	defer disp.Stop()
 
 	// errs is indexed by host position so results are collected in host-list
@@ -117,11 +111,11 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOpti
 		}
 	}
 
-	sem := make(chan struct{}, opts.MaxConcurrentHosts)
+	sem := make(chan struct{}, cfg.MaxConcurrentHosts)
 	var ctxErr error
 loop:
 	for i, host := range hosts {
-		if opts.MaxConcurrentHosts <= 1 {
+		if cfg.MaxConcurrentHosts <= 1 {
 			processHost(i, host)
 		} else {
 			wg.Add(1)

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -51,6 +51,11 @@ var Command = []*cli.Command{
 				return err
 			}
 
+			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
+			if err != nil {
+				return err
+			}
+
 			// Build updates configuration from CLI flags
 			updatesCfg := UpdatesConfig{
 				UpdatesApply: cmd.Bool("updates-apply"),
@@ -61,7 +66,11 @@ var Command = []*cli.Command{
 				SSHConnectionFactory: ssh.CreateConnection,
 				ReconnectDelay:       10 * time.Second,
 			}
-			opts := RunUpdatesOptions{Debug: coreCfg.Debug, MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent}
+			opts := RunUpdatesOptions{
+				Debug:              coreCfg.Debug,
+				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
+				DisplayMode:        displayMode,
+			}
 
 			return runUpdatesForHosts(ctx, coreCfg.Hosts, opts, updatesCfg, deps, os.Stdout)
 		},
@@ -73,10 +82,12 @@ var Command = []*cli.Command{
 type RunUpdatesOptions struct {
 	Debug              bool
 	MaxConcurrentHosts int
+	DisplayMode        display.Mode
 }
 
 func runUpdatesForHosts(ctx context.Context, hosts []string, opts RunUpdatesOptions, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, opts.Debug)
+	disp.SetMode(opts.DisplayMode)
 	disp.SetConcurrent(opts.MaxConcurrentHosts > 1)
 	disp.Start()
 	defer disp.Stop()

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hekmon/liveterm/v2"
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/display"
@@ -81,19 +80,11 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, 
 		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
 
-	var restoreLogger func()
-	if disp.LiveMode() {
-		previousLogger := slog.Default()
-		logLevel := slog.LevelWarn
-		if cfg.Debug {
-			logLevel = slog.LevelDebug
-		}
-		handler := slog.NewTextHandler(liveterm.Bypass(), &slog.HandlerOptions{Level: logLevel})
-		slog.SetDefault(slog.New(handler))
-		restoreLogger = func() {
-			slog.SetDefault(previousLogger)
-		}
+	logLevel := slog.LevelWarn
+	if cfg.Debug {
+		logLevel = slog.LevelDebug
 	}
+	restoreLogger := core.RedirectDefaultLogger(disp.LogWriter(), logLevel)
 
 	// errs is indexed by host position so results are collected in host-list
 	// order regardless of goroutine completion order.
@@ -145,9 +136,7 @@ loop:
 	wg.Wait()
 	result := errors.Join(append(errs, ctxErr)...)
 	disp.Stop()
-	if restoreLogger != nil {
-		restoreLogger()
-	}
+	restoreLogger()
 	return result
 }
 

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -22,7 +22,7 @@ type UpdatesConfig struct {
 	UpdatesApply       bool
 	Debug              bool
 	MaxConcurrentHosts int
-	DisplayMode        display.Mode
+	PreferLiveMode     bool
 }
 
 // ErrCannotCheckUpdates is returned when the update status cannot be determined,
@@ -54,17 +54,12 @@ var Command = []*cli.Command{
 				return err
 			}
 
-			displayMode, err := display.ParseMode(coreCfg.DisplayMode)
-			if err != nil {
-				return err
-			}
-
 			// Build updates configuration from CLI flags
 			updatesCfg := UpdatesConfig{
 				UpdatesApply:       cmd.Bool("updates-apply"),
 				Debug:              coreCfg.Debug,
 				MaxConcurrentHosts: coreCfg.EffectiveMaxConcurrent,
-				DisplayMode:        displayMode,
+				PreferLiveMode:     coreCfg.PreferLiveMode,
 			}
 
 			// Build dependencies
@@ -80,9 +75,9 @@ var Command = []*cli.Command{
 
 func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, deps UpdatesDependencies, out io.Writer) error {
 	disp := display.New(out, hosts, display.InitOptions{
-		Debug:      cfg.Debug,
-		Mode:       cfg.DisplayMode,
-		Concurrent: cfg.MaxConcurrentHosts > 1,
+		Debug:          cfg.Debug,
+		PreferLiveMode: cfg.PreferLiveMode,
+		Concurrent:     cfg.MaxConcurrentHosts > 1,
 	})
 	defer disp.Stop()
 

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
+	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -1424,11 +1425,10 @@ func TestRunUpdatesForHosts_Sequential(t *testing.T) {
 		ReconnectDelay: 10 * time.Millisecond,
 	}
 
-	cfg := UpdatesConfig{UpdatesApply: true}
-	opts := RunUpdatesOptions{Debug: true, MaxConcurrentHosts: 1}
+	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runUpdatesForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
 	}
@@ -1515,11 +1515,10 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 		ReconnectDelay:       10 * time.Millisecond,
 	}
 
-	cfg := UpdatesConfig{UpdatesApply: true}
-	opts := RunUpdatesOptions{Debug: true, MaxConcurrentHosts: len(hosts)}
+	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
 
 	var out bytes.Buffer
-	err := runUpdatesForHosts(context.Background(), hosts, opts, cfg, deps, &out)
+	err := runUpdatesForHosts(context.Background(), hosts, cfg, deps, &out)
 	if err == nil {
 		t.Fatal("runUpdatesForHosts() expected a non-nil error for router-apply-fail, got nil")
 	}

--- a/cmd/updates/updates_test.go
+++ b/cmd/updates/updates_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
-	"jb.favre/mikrotik-fleet-autopilot/common/display"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 	"jb.favre/mikrotik-fleet-autopilot/common/sshmocks_test"
 )
@@ -1425,7 +1424,7 @@ func TestRunUpdatesForHosts_Sequential(t *testing.T) {
 		ReconnectDelay: 10 * time.Millisecond,
 	}
 
-	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: 1, DisplayMode: display.ModeAuto}
+	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: 1, PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runUpdatesForHosts(context.Background(), hosts, cfg, deps, &out)
@@ -1515,7 +1514,7 @@ func TestRunUpdatesForHosts_Concurrent(t *testing.T) {
 		ReconnectDelay:       10 * time.Millisecond,
 	}
 
-	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: len(hosts), DisplayMode: display.ModeAuto}
+	cfg := UpdatesConfig{UpdatesApply: true, Debug: true, MaxConcurrentHosts: len(hosts), PreferLiveMode: true}
 
 	var out bytes.Buffer
 	err := runUpdatesForHosts(context.Background(), hosts, cfg, deps, &out)

--- a/common/core/common.go
+++ b/common/core/common.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // ContextKey is a custom type for context keys to avoid collisions
@@ -22,6 +23,31 @@ const (
 	// EnrollmentKey is the context key for storing enrollment mode
 	EnrollmentKey ContextKey = "enrollment"
 )
+
+type slogRouterWriter struct {
+	mu       sync.RWMutex
+	fallback io.Writer
+	live     io.Writer
+}
+
+func (w *slogRouterWriter) Write(p []byte) (int, error) {
+	w.mu.RLock()
+	live := w.live
+	fallback := w.fallback
+	w.mu.RUnlock()
+	if live != nil {
+		return live.Write(p)
+	}
+	return fallback.Write(p)
+}
+
+func (w *slogRouterWriter) SetLiveWriter(writer io.Writer) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.live = writer
+}
+
+var defaultSlogWriter = &slogRouterWriter{fallback: os.Stderr}
 
 // GetConfig extracts *config.Config from context
 func GetConfig(ctx context.Context) (*Config, error) {
@@ -50,22 +76,14 @@ func IsEnrollmentMode(ctx context.Context) bool {
 
 // SetupLogging sets slog default logger to the given level
 func SetupLogging(level slog.Level) {
-	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	handler := slog.NewTextHandler(defaultSlogWriter, &slog.HandlerOptions{Level: level})
 	slog.SetDefault(slog.New(handler))
 }
 
-// RedirectDefaultLogger temporarily routes the default slog logger to writer.
-// The returned function restores the previous default logger.
-func RedirectDefaultLogger(writer io.Writer, level slog.Level) func() {
-	if writer == nil {
-		return func() {}
-	}
-	previousLogger := slog.Default()
-	handler := slog.NewTextHandler(writer, &slog.HandlerOptions{Level: level})
-	slog.SetDefault(slog.New(handler))
-	return func() {
-		slog.SetDefault(previousLogger)
-	}
+// SetLiveLogWriter routes slog output to writer while live display is active.
+// Pass nil to disable live routing and fall back to stderr.
+func SetLiveLogWriter(writer io.Writer) {
+	defaultSlogWriter.SetLiveWriter(writer)
 }
 
 // ParseHosts parses a comma-separated list of hosts and returns a slice of trimmed host strings.

--- a/common/core/common.go
+++ b/common/core/common.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -51,6 +52,20 @@ func IsEnrollmentMode(ctx context.Context) bool {
 func SetupLogging(level slog.Level) {
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
 	slog.SetDefault(slog.New(handler))
+}
+
+// RedirectDefaultLogger temporarily routes the default slog logger to writer.
+// The returned function restores the previous default logger.
+func RedirectDefaultLogger(writer io.Writer, level slog.Level) func() {
+	if writer == nil {
+		return func() {}
+	}
+	previousLogger := slog.Default()
+	handler := slog.NewTextHandler(writer, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
+	return func() {
+		slog.SetDefault(previousLogger)
+	}
 }
 
 // ParseHosts parses a comma-separated list of hosts and returns a slice of trimmed host strings.

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	SkipHostKeyCheck       bool
 	MaxConcurrentHosts     int
 	EffectiveMaxConcurrent int
-	DisplayMode            string
+	BufferedOutput         bool
+	PreferLiveMode         bool
 }
 
 // ResolveMaxConcurrentHosts returns the effective host concurrency cap.

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	SkipHostKeyCheck       bool
 	MaxConcurrentHosts     int
 	EffectiveMaxConcurrent int
+	DisplayMode            string
 }
 
 // ResolveMaxConcurrentHosts returns the effective host concurrency cap.

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -287,6 +287,11 @@ func (d *LiveDisplay) Line(i int) *HostLine {
 	return d.lines[i]
 }
 
+// LiveMode reports whether the display is effectively running in live mode.
+func (d *LiveDisplay) LiveMode() bool {
+	return d.liveMode
+}
+
 // start begins live output. In fallback mode this is a no-op.
 // Only one LiveDisplay may be in live mode at a time: if another display is
 // already active, start falls back to plain-text mode so that the existing

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -18,36 +18,14 @@ const (
 	maxHostnameWidth = 20
 )
 
-// Mode controls how concurrent output is rendered.
-type Mode string
-
-const (
-	ModeAuto     Mode = "auto"
-	ModeBuffered Mode = "buffered"
-)
-
 // InitOptions configures display initialization parameters.
 type InitOptions struct {
 	// Debug indicates whether --debug is enabled. Debug has priority and disables live mode.
 	Debug bool
-	// Mode controls the display behavior (auto or buffered).
-	Mode Mode
+	// PreferLiveMode indicates whether live rendering is preferred when possible.
+	PreferLiveMode bool
 	// Concurrent enables ordered buffering when live mode is off.
 	Concurrent bool
-}
-
-// ParseMode parses a user-provided mode value.
-func ParseMode(value string) (Mode, error) {
-	mode := Mode(strings.ToLower(strings.TrimSpace(value)))
-	if mode == "" {
-		return ModeAuto, nil
-	}
-	switch mode {
-	case ModeAuto, ModeBuffered:
-		return mode, nil
-	default:
-		return "", fmt.Errorf("invalid display mode %q: must be auto or buffered", value)
-	}
 }
 
 // completedStep records an already-finished step with its emoticon.
@@ -233,9 +211,9 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 		}
 	}
 
-	// Centralize mode and concurrency setup in one place so constructor and
+	// Centralize live preference and concurrency setup in one place so constructor and
 	// runtime behavior match.
-	d.applyMode(opts.Mode)
+	d.applyMode(opts.PreferLiveMode)
 	d.setConcurrent(opts.Concurrent)
 	d.start()
 
@@ -248,25 +226,14 @@ func (d *LiveDisplay) setConcurrent(concurrent bool) {
 	d.applyConcurrencyBuffering()
 }
 
-func (d *LiveDisplay) applyMode(mode Mode) {
+func (d *LiveDisplay) applyMode(preferLiveMode bool) {
 	// Debug flag has priority: if --debug is enabled, always disable live mode
 	// to keep output clean and deterministic for log analysis.
 	if d.debug {
 		d.setLiveMode(false)
 	} else {
-		var shouldLive bool
-
-		switch mode {
-		case ModeBuffered:
-			// Explicitly buffered: never use live updates
-			shouldLive = false
-		case ModeAuto:
-			shouldLive = d.isTTY
-		default:
-			// Unknown/zero values are treated like auto for defensive behavior.
-			shouldLive = d.isTTY
-		}
-
+		// Live mode is enabled only when preferred and when a TTY is available.
+		shouldLive := preferLiveMode && d.isTTY
 		d.setLiveMode(shouldLive)
 	}
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -26,6 +26,16 @@ const (
 	ModeBuffered Mode = "buffered"
 )
 
+// InitOptions configures display initialization parameters.
+type InitOptions struct {
+	// Debug indicates whether --debug is enabled. Debug has priority and disables live mode.
+	Debug bool
+	// Mode controls the display behavior (auto or buffered).
+	Mode Mode
+	// Concurrent enables ordered buffering when live mode is off.
+	Concurrent bool
+}
+
 // ParseMode parses a user-provided mode value.
 func ParseMode(value string) (Mode, error) {
 	mode := Mode(strings.ToLower(strings.TrimSpace(value)))
@@ -181,10 +191,8 @@ type LiveDisplay struct {
 	lines []*HostLine
 	out   io.Writer
 
-	// mode is the requested display policy configured by callers.
-	mode Mode
-	// liveMode is the effective runtime state after evaluating mode, debug, TTY,
-	// and any live startup fallback (for example singleton contention).
+	// liveMode is the effective runtime state after evaluating display mode,
+	// debug, TTY, and any live startup fallback (for example singleton contention).
 	liveMode bool
 
 	// isTTY is detected once at construction time and does not change.
@@ -198,11 +206,10 @@ type LiveDisplay struct {
 	pendingLines []string
 }
 
-// New creates a LiveDisplay. TTY detection is performed at construction time,
-// and the result is independent of the debug flag. Whether live mode is actually
-// enabled depends on both TTY capability and the display mode (which respects the
-// debug flag via applyMode).
-func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
+// New creates and initializes a LiveDisplay.
+// It applies display mode policy, configures concurrency behavior, and starts
+// live rendering when applicable.
+func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	isTTY := false
 	if f, ok := out.(*os.File); ok {
 		isTTY = term.IsTerminal(int(f.Fd()))
@@ -212,8 +219,7 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 	d := &LiveDisplay{
 		lines: make([]*HostLine, len(hosts)),
 		isTTY: isTTY,
-		debug: debug,
-		mode:  ModeAuto,
+		debug: opts.Debug,
 		out:   out,
 	}
 
@@ -227,27 +233,22 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 		}
 	}
 
-	// Centralize mode setup in one place so constructor and runtime behavior match.
-	d.applyMode()
+	// Centralize mode and concurrency setup in one place so constructor and
+	// runtime behavior match.
+	d.applyMode(opts.Mode)
+	d.setConcurrent(opts.Concurrent)
+	d.start()
 
 	return d
 }
 
-// SetMode configures how concurrent output is rendered.
-// Must be called before Start.
-func (d *LiveDisplay) SetMode(mode Mode) {
-	d.mode = mode
-	d.applyMode()
-}
-
-// SetConcurrent marks the display as serving concurrent host processing.
-// Must be called before Start.
-func (d *LiveDisplay) SetConcurrent(concurrent bool) {
+// setConcurrent marks the display as serving concurrent host processing.
+func (d *LiveDisplay) setConcurrent(concurrent bool) {
 	d.concurrent = concurrent
-	d.applyMode()
+	d.applyConcurrencyBuffering()
 }
 
-func (d *LiveDisplay) applyMode() {
+func (d *LiveDisplay) applyMode(mode Mode) {
 	// Debug flag has priority: if --debug is enabled, always disable live mode
 	// to keep output clean and deterministic for log analysis.
 	if d.debug {
@@ -255,7 +256,7 @@ func (d *LiveDisplay) applyMode() {
 	} else {
 		var shouldLive bool
 
-		switch d.mode {
+		switch mode {
 		case ModeBuffered:
 			// Explicitly buffered: never use live updates
 			shouldLive = false
@@ -269,6 +270,12 @@ func (d *LiveDisplay) applyMode() {
 		d.setLiveMode(shouldLive)
 	}
 
+	d.applyConcurrencyBuffering()
+}
+
+// applyConcurrencyBuffering configures whether host lines are buffered until
+// Stop based on current concurrency + effective live mode.
+func (d *LiveDisplay) applyConcurrencyBuffering() {
 	// Concurrent runs in non-live mode are buffered so Stop can emit
 	// deterministic host-list ordering for non-interactive outputs.
 	if d.concurrent && !d.liveMode {
@@ -312,11 +319,11 @@ func (d *LiveDisplay) Line(i int) *HostLine {
 	return d.lines[i]
 }
 
-// Start begins live output. In fallback mode this is a no-op.
+// start begins live output. In fallback mode this is a no-op.
 // Only one LiveDisplay may be in live mode at a time: if another display is
-// already active, Start falls back to plain-text mode so that the existing
+// already active, start falls back to plain-text mode so that the existing
 // liveterm instance is not disturbed.
-func (d *LiveDisplay) Start() {
+func (d *LiveDisplay) start() {
 	if !d.liveMode {
 		return
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -292,6 +292,15 @@ func (d *LiveDisplay) LiveMode() bool {
 	return d.liveMode
 }
 
+// LogWriter returns a writer safe to use for permanent log output while the
+// live display is active.
+func (d *LiveDisplay) LogWriter() io.Writer {
+	if !d.liveMode {
+		return nil
+	}
+	return liveterm.Bypass()
+}
+
 // start begins live output. In fallback mode this is a no-op.
 // Only one LiveDisplay may be in live mode at a time: if another display is
 // already active, start falls back to plain-text mode so that the existing

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -24,7 +24,6 @@ type Mode string
 const (
 	ModeAuto     Mode = "auto"
 	ModeBuffered Mode = "buffered"
-	ModeLive     Mode = "live"
 )
 
 // ParseMode parses a user-provided mode value.
@@ -34,19 +33,11 @@ func ParseMode(value string) (Mode, error) {
 		return ModeAuto, nil
 	}
 	switch mode {
-	case ModeAuto, ModeBuffered, ModeLive:
+	case ModeAuto, ModeBuffered:
 		return mode, nil
 	default:
-		return "", fmt.Errorf("invalid display mode %q: must be auto, buffered, or live", value)
+		return "", fmt.Errorf("invalid display mode %q: must be auto or buffered", value)
 	}
-}
-
-// NormalizeMode coerces zero values to ModeAuto.
-func NormalizeMode(mode Mode) Mode {
-	if strings.TrimSpace(string(mode)) == "" {
-		return ModeAuto
-	}
-	return mode
 }
 
 // completedStep records an already-finished step with its emoticon.
@@ -187,31 +178,43 @@ var (
 
 // LiveDisplay manages per-host live output lines.
 type LiveDisplay struct {
-	lines        []*HostLine
-	liveMode     bool
-	baseLiveMode bool
-	concurrent   bool // when true, non-live Finish buffers; Stop flushes in host-list order
-	mode         Mode
-	out          io.Writer
-	pendingLines []string // non-live concurrent mode: one buffered output line per host, flushed in order by Stop
+	lines []*HostLine
+	out   io.Writer
+
+	// mode is the requested display policy configured by callers.
+	mode Mode
+	// liveMode is the effective runtime state after evaluating mode, debug, TTY,
+	// and any live startup fallback (for example singleton contention).
+	liveMode bool
+
+	// isTTY is detected once at construction time and does not change.
+	isTTY bool
+	// debug indicates whether --debug is enabled. Debug has priority and disables live mode.
+	debug bool
+	// concurrent enables ordered buffering when live mode is off.
+	concurrent bool
+
+	// pendingLines holds one rendered final line per host in concurrent non-live mode.
+	pendingLines []string
 }
 
-// New creates a LiveDisplay. If debug=true or stdout is not a TTY, falls back to verbose mode.
+// New creates a LiveDisplay. TTY detection is performed at construction time,
+// and the result is independent of the debug flag. Whether live mode is actually
+// enabled depends on both TTY capability and the display mode (which respects the
+// debug flag via applyMode).
 func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
-	liveMode := false
-	if !debug {
-		if f, ok := out.(*os.File); ok {
-			liveMode = term.IsTerminal(int(f.Fd()))
-		}
+	isTTY := false
+	if f, ok := out.(*os.File); ok {
+		isTTY = term.IsTerminal(int(f.Fd()))
 	}
 	hostnameWidth := computeHostnameWidth(hosts)
 
 	d := &LiveDisplay{
-		lines:        make([]*HostLine, len(hosts)),
-		liveMode:     liveMode,
-		baseLiveMode: liveMode,
-		mode:         ModeAuto,
-		out:          out,
+		lines: make([]*HostLine, len(hosts)),
+		isTTY: isTTY,
+		debug: debug,
+		mode:  ModeAuto,
+		out:   out,
 	}
 
 	for i, host := range hosts {
@@ -219,11 +222,13 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 			hostname:      host,
 			hostnameWidth: hostnameWidth,
 			overallEmoji:  "⏳",
-			liveMode:      liveMode,
 			index:         i,
 			out:           out,
 		}
 	}
+
+	// Centralize mode setup in one place so constructor and runtime behavior match.
+	d.applyMode()
 
 	return d
 }
@@ -231,7 +236,7 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 // SetMode configures how concurrent output is rendered.
 // Must be called before Start.
 func (d *LiveDisplay) SetMode(mode Mode) {
-	d.mode = NormalizeMode(mode)
+	d.mode = mode
 	d.applyMode()
 }
 
@@ -243,14 +248,26 @@ func (d *LiveDisplay) SetConcurrent(concurrent bool) {
 }
 
 func (d *LiveDisplay) applyMode() {
-	mode := NormalizeMode(d.mode)
-	shouldLive := d.baseLiveMode
+	// Debug flag has priority: if --debug is enabled, always disable live mode
+	// to keep output clean and deterministic for log analysis.
+	if d.debug {
+		d.setLiveMode(false)
+	} else {
+		var shouldLive bool
 
-	if mode == ModeBuffered {
-		shouldLive = false
+		switch d.mode {
+		case ModeBuffered:
+			// Explicitly buffered: never use live updates
+			shouldLive = false
+		case ModeAuto:
+			shouldLive = d.isTTY
+		default:
+			// Unknown/zero values are treated like auto for defensive behavior.
+			shouldLive = d.isTTY
+		}
+
+		d.setLiveMode(shouldLive)
 	}
-
-	d.setLiveMode(shouldLive)
 
 	// Concurrent runs in non-live mode are buffered so Stop can emit
 	// deterministic host-list ordering for non-interactive outputs.

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -48,6 +48,7 @@ type HostLine struct {
 	done          bool
 	finalMessage  string // set by Finish; does not include the hostname or overall emoji
 	liveMode      bool
+	renderedLine  string // cached final rendered line after Finish(); prevents state changes from affecting output
 }
 
 // StepCallback is used to update step display for a host.
@@ -361,10 +362,29 @@ func (d *LiveDisplay) Stop() {
 }
 
 // renderLines returns all host lines for liveterm to display.
+// This implementation atomically captures the state of all lines to prevent race
+// conditions where intermediate states (e.g., ⏳ Connecting…) are visible alongside
+// final states (e.g., ✅ or ❓). By acquiring all locks in order before rendering,
+// we ensure the snapshot is consistent and matches the moment in time it was taken.
+// WARNING: removing the locks or changing the locking strategy may cause race conditions
+// WARNING: where intermediate states are rendered alongside final states, leading to confusing output.
+// WARNING: Do not modify without careful consideration.
 func (d *LiveDisplay) renderLines() []string {
+	// Acquire all locks in index order to prevent deadlock and capture an atomic snapshot.
+	for _, l := range d.lines {
+		l.mu.Lock()
+	}
+	defer func() {
+		// Release all locks in reverse order to maintain consistency.
+		for i := len(d.lines) - 1; i >= 0; i-- {
+			d.lines[i].mu.Unlock()
+		}
+	}()
+
+	// Now render all lines while holding all locks; no state can change during this render.
 	out := make([]string, len(d.lines))
 	for i, l := range d.lines {
-		out[i] = l.render()
+		out[i] = l.renderUnlocked()
 	}
 	return out
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -18,6 +18,37 @@ const (
 	maxHostnameWidth = 20
 )
 
+// Mode controls how concurrent output is rendered.
+type Mode string
+
+const (
+	ModeAuto     Mode = "auto"
+	ModeBuffered Mode = "buffered"
+	ModeLive     Mode = "live"
+)
+
+// ParseMode parses a user-provided mode value.
+func ParseMode(value string) (Mode, error) {
+	mode := Mode(strings.ToLower(strings.TrimSpace(value)))
+	if mode == "" {
+		return ModeAuto, nil
+	}
+	switch mode {
+	case ModeAuto, ModeBuffered, ModeLive:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid display mode %q: must be auto, buffered, or live", value)
+	}
+}
+
+// NormalizeMode coerces zero values to ModeAuto.
+func NormalizeMode(mode Mode) Mode {
+	if strings.TrimSpace(string(mode)) == "" {
+		return ModeAuto
+	}
+	return mode
+}
+
 // completedStep records an already-finished step with its emoticon.
 type completedStep struct {
 	emoji string
@@ -158,7 +189,9 @@ var (
 type LiveDisplay struct {
 	lines        []*HostLine
 	liveMode     bool
+	baseLiveMode bool
 	concurrent   bool // when true, non-live Finish buffers; Stop flushes in host-list order
+	mode         Mode
 	out          io.Writer
 	pendingLines []string // non-live concurrent mode: one buffered output line per host, flushed in order by Stop
 }
@@ -174,9 +207,11 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 	hostnameWidth := computeHostnameWidth(hosts)
 
 	d := &LiveDisplay{
-		lines:    make([]*HostLine, len(hosts)),
-		liveMode: liveMode,
-		out:      out,
+		lines:        make([]*HostLine, len(hosts)),
+		liveMode:     liveMode,
+		baseLiveMode: liveMode,
+		mode:         ModeAuto,
+		out:          out,
 	}
 
 	for i, host := range hosts {
@@ -193,31 +228,45 @@ func New(out io.Writer, hosts []string, debug bool) *LiveDisplay {
 	return d
 }
 
+// SetMode configures how concurrent output is rendered.
+// Must be called before Start.
+func (d *LiveDisplay) SetMode(mode Mode) {
+	d.mode = NormalizeMode(mode)
+	d.applyMode()
+}
+
 // SetConcurrent marks the display as serving concurrent host processing.
-// Must be called before Start. In concurrent mode the display always uses
-// non-live buffered output — even on a real TTY — so that goroutines finishing
-// at arbitrary times produce clean, deterministic one-line-per-host output
-// flushed in host-list order by Stop. Using liveterm with concurrent goroutines
-// causes intermediate step renders to appear in the scrollback, which is why
-// this path unconditionally disables live mode.
-// In the default sequential mode, Finish writes each line immediately so the
-// caller sees per-host progress in real time.
+// Must be called before Start.
 func (d *LiveDisplay) SetConcurrent(concurrent bool) {
 	d.concurrent = concurrent
-	if !concurrent {
-		d.clearNonLive()
+	d.applyMode()
+}
+
+func (d *LiveDisplay) applyMode() {
+	mode := NormalizeMode(d.mode)
+	shouldLive := d.baseLiveMode
+
+	if mode == ModeBuffered {
+		shouldLive = false
+	}
+
+	d.setLiveMode(shouldLive)
+
+	// Concurrent runs in non-live mode are buffered so Stop can emit
+	// deterministic host-list ordering for non-interactive outputs.
+	if d.concurrent && !d.liveMode {
+		if d.pendingLines == nil {
+			d.initNonLive()
+		}
 		return
 	}
-	// Concurrent mode always uses non-live buffered output regardless of TTY.
-	// Force liveMode off before Start is called so liveterm is never started.
-	if d.liveMode {
-		d.liveMode = false
-		for _, l := range d.lines {
-			l.liveMode = false
-		}
-	}
-	if d.pendingLines == nil {
-		d.initNonLive()
+	d.clearNonLive()
+}
+
+func (d *LiveDisplay) setLiveMode(enabled bool) {
+	d.liveMode = enabled
+	for _, l := range d.lines {
+		l.liveMode = enabled
 	}
 }
 
@@ -259,10 +308,7 @@ func (d *LiveDisplay) Start() {
 	// liveterm.Start so the refresh goroutine can acquire it if needed.
 	if !d.tryClaim() {
 		// Another display is already running; fall back to plain text.
-		d.liveMode = false
-		for _, l := range d.lines {
-			l.liveMode = false
-		}
+		d.setLiveMode(false)
 		if d.concurrent {
 			d.initNonLive()
 		}
@@ -275,10 +321,7 @@ func (d *LiveDisplay) Start() {
 	if err := liveterm.Start(); err != nil {
 		// If liveterm fails to start (e.g. no real TTY despite fd check), fall back.
 		d.release()
-		d.liveMode = false
-		for _, l := range d.lines {
-			l.liveMode = false
-		}
+		d.setLiveMode(false)
 		if d.concurrent {
 			d.initNonLive()
 		}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -48,7 +48,6 @@ type HostLine struct {
 	done          bool
 	finalMessage  string // set by Finish; does not include the hostname or overall emoji
 	liveMode      bool
-	renderedLine  string // cached final rendered line after Finish(); prevents state changes from affecting output
 }
 
 // StepCallback is used to update step display for a host.

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -509,7 +509,6 @@ func TestConcurrentFailureRenderAtomicity(t *testing.T) {
 	// Create a live-mode display (simulated; not actually running liveterm).
 	d := newLiveModeDisplay(&buf, hosts)
 
-	const numWorkers = 50 // High concurrency to increase chance of hitting race condition
 	var wg sync.WaitGroup
 
 	// Simulate concurrent host processing: some succeed, router32 and router70 fail

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -17,10 +17,69 @@ func newTestDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 	d := New(out, hosts, true) // starts in fallback
 	d.liveMode = true          // pretend it is live-capable
+	d.baseLiveMode = true
 	for _, l := range d.lines {
 		l.liveMode = true
 	}
 	return d
+}
+
+func TestSetConcurrentAutoKeepsLiveWhenCapable(t *testing.T) {
+	var buf bytes.Buffer
+	d := newLiveModeDisplay(&buf, []string{"router1"})
+	d.SetMode(ModeAuto)
+	d.SetConcurrent(true)
+
+	if !d.liveMode {
+		t.Fatal("expected live mode to stay enabled in concurrent auto mode on a live-capable terminal")
+	}
+	if d.pendingLines != nil {
+		t.Fatalf("expected no buffered pending lines in concurrent auto live mode, got %#v", d.pendingLines)
+	}
+}
+
+func TestSetModeBufferedForcesConcurrentBuffering(t *testing.T) {
+	var buf bytes.Buffer
+	d := newLiveModeDisplay(&buf, []string{"router1", "router2"})
+	d.SetMode(ModeBuffered)
+	d.SetConcurrent(true)
+
+	if d.liveMode {
+		t.Fatal("expected live mode to be disabled in buffered mode")
+	}
+	if d.pendingLines == nil || len(d.pendingLines) != 2 {
+		t.Fatalf("expected pending lines buffer of size 2, got %#v", d.pendingLines)
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Mode
+		wantErr bool
+	}{
+		{name: "empty defaults to auto", input: "", want: ModeAuto},
+		{name: "auto", input: "auto", want: ModeAuto},
+		{name: "buffered", input: "buffered", want: ModeBuffered},
+		{name: "live", input: "live", want: ModeLive},
+		{name: "invalid", input: "stream", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("ParseMode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestNewFallbackMode(t *testing.T) {

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -9,14 +9,14 @@ import (
 
 // newTestDisplay creates a LiveDisplay in non-TTY/debug fallback mode for testing.
 func newTestDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
-	return New(out, hosts, InitOptions{Debug: true, Mode: ModeAuto, Concurrent: false})
+	return New(out, hosts, InitOptions{Debug: true, PreferLiveMode: true, Concurrent: false})
 }
 
 // newLiveModeDisplay creates a LiveDisplay that believes it is in live mode,
 // without actually starting liveterm (for singleton guard testing).
 func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
-	d := New(out, hosts, InitOptions{Debug: true, Mode: ModeAuto, Concurrent: false}) // starts in fallback
-	d.liveMode = true                                                                 // pretend it is live-capable
+	d := New(out, hosts, InitOptions{Debug: true, PreferLiveMode: true, Concurrent: false}) // starts in fallback
+	d.liveMode = true                                                                       // pretend it is live-capable
 	d.isTTY = true
 	d.debug = false
 	for _, l := range d.lines {
@@ -25,11 +25,11 @@ func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 	return d
 }
 
-func TestSetConcurrentAutoKeepsLiveWhenCapable(t *testing.T) {
+func TestPreferLiveKeepsLiveWhenCapable(t *testing.T) {
 	var buf bytes.Buffer
-	d := New(&buf, []string{"router1"}, InitOptions{Debug: false, Mode: ModeAuto, Concurrent: true})
+	d := New(&buf, []string{"router1"}, InitOptions{Debug: false, PreferLiveMode: true, Concurrent: true})
 	d.isTTY = true
-	d.applyMode(ModeAuto)
+	d.applyMode(true)
 
 	if !d.liveMode {
 		t.Fatal("expected live mode to stay enabled in concurrent auto mode on a live-capable terminal")
@@ -39,47 +39,17 @@ func TestSetConcurrentAutoKeepsLiveWhenCapable(t *testing.T) {
 	}
 }
 
-func TestSetModeBufferedForcesConcurrentBuffering(t *testing.T) {
+func TestBufferedPreferenceForcesConcurrentBuffering(t *testing.T) {
 	var buf bytes.Buffer
-	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, Mode: ModeBuffered, Concurrent: true})
+	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, PreferLiveMode: false, Concurrent: true})
 	d.isTTY = true
-	d.applyMode(ModeBuffered)
+	d.applyMode(false)
 
 	if d.liveMode {
 		t.Fatal("expected live mode to be disabled in buffered mode")
 	}
 	if d.pendingLines == nil || len(d.pendingLines) != 2 {
 		t.Fatalf("expected pending lines buffer of size 2, got %#v", d.pendingLines)
-	}
-}
-
-func TestParseMode(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    Mode
-		wantErr bool
-	}{
-		{name: "empty defaults to auto", input: "", want: ModeAuto},
-		{name: "auto", input: "auto", want: ModeAuto},
-		{name: "buffered", input: "buffered", want: ModeBuffered},
-		{name: "live is now invalid", input: "live", wantErr: true},
-		{name: "invalid", input: "stream", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseMode(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ParseMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-			if got != tt.want {
-				t.Fatalf("ParseMode(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -231,7 +201,7 @@ func TestMultipleHosts(t *testing.T) {
 func TestOutputOrder(t *testing.T) {
 	hosts := []string{"host1.example.com", "host2.example.com", "host3.example.com"}
 	var buf bytes.Buffer
-	d := New(&buf, hosts, InitOptions{Debug: false, Mode: ModeBuffered, Concurrent: true})
+	d := New(&buf, hosts, InitOptions{Debug: false, PreferLiveMode: false, Concurrent: true})
 
 	// Finish hosts in reverse order to simulate out-of-order concurrent completion.
 	d.Line(2).Finish("✅", "host3 done")

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -496,3 +496,118 @@ func resetSingleton(t *testing.T) {
 		singletonMu.Unlock()
 	})
 }
+
+// TestConcurrentFailureRenderAtomicity verifies that when hosts complete concurrently
+// with mixed success and failures, renderLines() produces an atomic snapshot without
+// intermediate states (e.g., "⏳ Connecting…") bleeding through into the output alongside
+// final states (e.g., "❓ failed to dial"). This test reproduces the bug scenario reported
+// in the issue where intermediate progress lines appeared mixed with final error messages.
+func TestConcurrentFailureRenderAtomicity(t *testing.T) {
+	hosts := []string{"router1", "router30", "router31", "router32", "router70", "router71", "router90"}
+	var buf bytes.Buffer
+
+	// Create a live-mode display (simulated; not actually running liveterm).
+	d := newLiveModeDisplay(&buf, hosts)
+
+	const numWorkers = 50 // High concurrency to increase chance of hitting race condition
+	var wg sync.WaitGroup
+
+	// Simulate concurrent host processing: some succeed, router32 and router70 fail
+	failingHosts := map[string]bool{"router32": true, "router70": true}
+
+	for i, host := range hosts {
+		wg.Add(1)
+		go func(idx int, hostname string) {
+			defer wg.Done()
+			line := d.Line(idx)
+			cb := NewStepCallback(line)
+
+			// All hosts go through "Connecting" phase
+			cb("⏳", "Connecting to router…")
+
+			// Simulate varying network delays by spinning briefly
+			for j := 0; j < 1000; j++ {
+				_ = d.renderLines() // Rapidly call renderLines to increase contention
+			}
+
+			// Some hosts fail, others succeed. This matches the actual processHost flow:
+			// 1. CompleteStep(emoji) adds to history
+			// 2. Finish(emoji, msg) sets overall emoji and marks done
+			if failingHosts[hostname] {
+				// Failed host reports error after "Connecting" step
+				cb("❓", "failed to dial: "+hostname+".home:22: dial tcp: lookup "+hostname+".home: no such host")
+				line.Finish("❓", "failed to dial: "+hostname+".home:22: dial tcp: lookup "+hostname+".home: no such host")
+			} else {
+				// Successful host reports completion
+				cb("✅", "is up-to-date (RouterOS: 7.22.1, RouterBoard: 7.22.1)")
+				line.Finish("✅", "is up-to-date (RouterOS: 7.22.1, RouterBoard: 7.22.1)")
+			}
+		}(i, host)
+	}
+
+	wg.Wait()
+
+	// After all goroutines complete, verify renderLines() produces a consistent snapshot.
+	// The snapshot should contain ONLY final states (✅, ❓), never intermediate states (⏳ Connecting).
+	snapshot := d.renderLines()
+
+	for i, line := range snapshot {
+		host := hosts[i]
+		t.Logf("Final snapshot for %s: %s", host, line)
+
+		// Every line should start with a final emoji, not intermediate
+		if !strings.HasPrefix(line, "✅") && !strings.HasPrefix(line, "❓") {
+			t.Errorf("snapshot[%d] for %q = %q, expected final emoji (✅ or ❓), not intermediate state",
+				i, host, line)
+		}
+
+		// No intermediate "Connecting" text should appear
+		if strings.Contains(line, "Connecting to router…") {
+			t.Errorf("snapshot[%d] for %q contains intermediate step 'Connecting to router…', should be final only: %q",
+				i, host, line)
+		}
+
+		// Verify expected final states
+		if failingHosts[host] {
+			if !strings.HasPrefix(line, "❓") {
+				t.Errorf("snapshot[%d] for %q = %q, expected ❓ (unknown/failed status)", i, host, line)
+			}
+			if !strings.Contains(line, "failed to dial") {
+				t.Errorf("snapshot[%d] for %q = %q, expected failure message", i, host, line)
+			}
+		} else {
+			if !strings.HasPrefix(line, "✅") {
+				t.Errorf("snapshot[%d] for %q = %q, expected ✅ (success)", i, host, line)
+			}
+			if !strings.Contains(line, "is up-to-date") {
+				t.Errorf("snapshot[%d] for %q = %q, expected success message", i, host, line)
+			}
+		}
+	}
+}
+
+// TestRenderLinesLocksAllHosts verifies that renderLines() correctly acquires and
+// releases locks on all hostlines, preventing race conditions during snapshot capture.
+// This test catches regressions if renderLines() ever reverts to acquiring locks
+// individually per-line instead of all-at-once.
+func TestRenderLinesLocksAllHosts(t *testing.T) {
+	hosts := []string{"host1", "host2", "host3"}
+	d := newLiveModeDisplay(new(bytes.Buffer), hosts)
+
+	// Set up each line with different states to verify they're all captured atomically
+	d.Line(0).UpdateStep("⏳", "step1")
+	d.Line(1).CompleteStep("✅")
+	d.Line(2).UpdateStep("⏳", "step2")
+
+	// Call renderLines multiple times: should always see the same state
+	// (deadlock would manifest as goroutine hanging, race detector would catch non-atomic reads)
+	for i := 0; i < 100; i++ {
+		snapshot := d.renderLines()
+		if len(snapshot) != 3 {
+			t.Errorf("iteration %d: renderLines returned %d lines, want 3", i, len(snapshot))
+		}
+		if !strings.Contains(snapshot[0], "step1") {
+			t.Errorf("iteration %d: snapshot[0] lost 'step1', got %q", i, snapshot[0])
+		}
+	}
+}

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -9,14 +9,14 @@ import (
 
 // newTestDisplay creates a LiveDisplay in non-TTY/debug fallback mode for testing.
 func newTestDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
-	return New(out, hosts, true)
+	return New(out, hosts, InitOptions{Debug: true, Mode: ModeAuto, Concurrent: false})
 }
 
 // newLiveModeDisplay creates a LiveDisplay that believes it is in live mode,
 // without actually starting liveterm (for singleton guard testing).
 func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
-	d := New(out, hosts, true) // starts in fallback
-	d.liveMode = true          // pretend it is live-capable
+	d := New(out, hosts, InitOptions{Debug: true, Mode: ModeAuto, Concurrent: false}) // starts in fallback
+	d.liveMode = true                                                                 // pretend it is live-capable
 	d.isTTY = true
 	d.debug = false
 	for _, l := range d.lines {
@@ -27,9 +27,9 @@ func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 
 func TestSetConcurrentAutoKeepsLiveWhenCapable(t *testing.T) {
 	var buf bytes.Buffer
-	d := newLiveModeDisplay(&buf, []string{"router1"})
-	d.SetMode(ModeAuto)
-	d.SetConcurrent(true)
+	d := New(&buf, []string{"router1"}, InitOptions{Debug: false, Mode: ModeAuto, Concurrent: true})
+	d.isTTY = true
+	d.applyMode(ModeAuto)
 
 	if !d.liveMode {
 		t.Fatal("expected live mode to stay enabled in concurrent auto mode on a live-capable terminal")
@@ -41,9 +41,9 @@ func TestSetConcurrentAutoKeepsLiveWhenCapable(t *testing.T) {
 
 func TestSetModeBufferedForcesConcurrentBuffering(t *testing.T) {
 	var buf bytes.Buffer
-	d := newLiveModeDisplay(&buf, []string{"router1", "router2"})
-	d.SetMode(ModeBuffered)
-	d.SetConcurrent(true)
+	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, Mode: ModeBuffered, Concurrent: true})
+	d.isTTY = true
+	d.applyMode(ModeBuffered)
 
 	if d.liveMode {
 		t.Fatal("expected live mode to be disabled in buffered mode")
@@ -97,8 +97,7 @@ func TestNewFallbackMode(t *testing.T) {
 func TestStartStopFallback(t *testing.T) {
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, []string{"router1"})
-	// In fallback mode Start is a no-op; Stop flushes buffered lines (none here).
-	d.Start()
+	// In fallback mode start is a no-op; Stop flushes buffered lines (none here).
 	d.Stop()
 }
 
@@ -232,8 +231,7 @@ func TestMultipleHosts(t *testing.T) {
 func TestOutputOrder(t *testing.T) {
 	hosts := []string{"host1.example.com", "host2.example.com", "host3.example.com"}
 	var buf bytes.Buffer
-	d := newTestDisplay(&buf, hosts)
-	d.SetConcurrent(true) // enable buffering so Stop flushes in host-list order
+	d := New(&buf, hosts, InitOptions{Debug: false, Mode: ModeBuffered, Concurrent: true})
 
 	// Finish hosts in reverse order to simulate out-of-order concurrent completion.
 	d.Line(2).Finish("✅", "host3 done")
@@ -471,10 +469,10 @@ func TestSingletonFallback(t *testing.T) {
 
 	// A second display in live mode should fall back to plain text.
 	second := newLiveModeDisplay(&buf2, []string{"router2"})
-	second.Start() // should detect activeLiveDisp != nil and fall back
+	second.start() // should detect activeLiveDisp != nil and fall back
 
 	if second.liveMode {
-		t.Error("second Start() should have fallen back to plain text when a display is already active")
+		t.Error("second start() should have fallen back to plain text when a display is already active")
 	}
 	for _, l := range second.lines {
 		if l.liveMode {

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -17,7 +17,8 @@ func newTestDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 	d := New(out, hosts, true) // starts in fallback
 	d.liveMode = true          // pretend it is live-capable
-	d.baseLiveMode = true
+	d.isTTY = true
+	d.debug = false
 	for _, l := range d.lines {
 		l.liveMode = true
 	}
@@ -62,7 +63,7 @@ func TestParseMode(t *testing.T) {
 		{name: "empty defaults to auto", input: "", want: ModeAuto},
 		{name: "auto", input: "auto", want: ModeAuto},
 		{name: "buffered", input: "buffered", want: ModeBuffered},
-		{name: "live", input: "live", want: ModeLive},
+		{name: "live is now invalid", input: "live", wantErr: true},
 		{name: "invalid", input: "stream", wantErr: true},
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,11 +100,12 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 		},
 		Commands: append(append(export.Command, updates.Command...), enroll.Command...),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			// Set log level
-			core.SetupLogging(slog.LevelWarn)
+			// Set log level once at startup.
+			logLevel := slog.LevelWarn
 			if globalConfig.Debug {
-				core.SetupLogging(slog.LevelDebug)
+				logLevel = slog.LevelDebug
 			}
+			core.SetupLogging(logLevel)
 			slog.Info("Starting global")
 
 			effectiveMaxConcurrent, err := core.ResolveMaxConcurrentHosts(globalConfig.MaxConcurrentHosts)

--- a/main.go
+++ b/main.go
@@ -91,6 +91,12 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Usage:       "Maximum number of hosts to process in parallel (0 = auto-detect, 1 = sequential, >=2 = parallel with that cap)",
 				Destination: &globalConfig.MaxConcurrentHosts,
 			},
+			&cli.StringFlag{
+				Name:        "display-mode",
+				Value:       "auto",
+				Usage:       "Display behavior for host progress (auto = live on TTY + buffered fallback, buffered = deterministic final flush, live = force live updates when supported)",
+				Destination: &globalConfig.DisplayMode,
+			},
 		},
 		Commands: append(append(export.Command, updates.Command...), enroll.Command...),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			&cli.StringFlag{
 				Name:        "display-mode",
 				Value:       "auto",
-				Usage:       "Display behavior for host progress (auto = live on TTY + buffered fallback, buffered = deterministic final flush, live = force live updates when supported)",
+				Usage:       "Display behavior for host progress (auto = live on TTY + buffered fallback, buffered = deterministic final flush). Note: --debug flag has priority and always disables live mode for cleaner logs",
 				Destination: &globalConfig.DisplayMode,
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -91,11 +91,11 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Usage:       "Maximum number of hosts to process in parallel (0 = auto-detect, 1 = sequential, >=2 = parallel with that cap)",
 				Destination: &globalConfig.MaxConcurrentHosts,
 			},
-			&cli.StringFlag{
-				Name:        "display-mode",
-				Value:       "auto",
-				Usage:       "Display behavior for host progress (auto = live on TTY + buffered fallback, buffered = deterministic final flush). Note: --debug flag has priority and always disables live mode for cleaner logs",
-				Destination: &globalConfig.DisplayMode,
+			&cli.BoolFlag{
+				Name:        "buffered-output",
+				Value:       false,
+				Usage:       "Force buffered host progress output (deterministic final flush). By default, live display is preferred on TTY unless --debug is enabled",
+				Destination: &globalConfig.BufferedOutput,
 			},
 		},
 		Commands: append(append(export.Command, updates.Command...), enroll.Command...),
@@ -113,6 +113,7 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			}
 			slog.Debug("resolved max concurrent hosts", "configured", globalConfig.MaxConcurrentHosts, "effective", effectiveMaxConcurrent)
 			globalConfig.EffectiveMaxConcurrent = effectiveMaxConcurrent
+			globalConfig.PreferLiveMode = !globalConfig.BufferedOutput
 
 			// Check if a subcommand was provided
 			// If not, the help will be shown automatically by urfave/cli

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func TestBuildCommandFlags(t *testing.T) {
 		"ssh-passphrase":       false,
 		"debug":                false,
 		"max-concurrent-hosts": false,
-		"display-mode":         false,
+		"buffered-output":      false,
 		"skip-hostkey-check":   false,
 	}
 
@@ -592,5 +592,61 @@ func TestBuildCommandMaxConcurrentHostsSequential(t *testing.T) {
 	}
 	if globalConfig.EffectiveMaxConcurrent != 1 {
 		t.Errorf("EffectiveMaxConcurrent = %d, want 1", globalConfig.EffectiveMaxConcurrent)
+	}
+}
+
+func TestBuildCommandBufferedOutputFlagDefault(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancel()
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "updates"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
+	}
+	if globalConfig.BufferedOutput {
+		t.Error("BufferedOutput = true, want false by default")
+	}
+	if !globalConfig.PreferLiveMode {
+		t.Error("PreferLiveMode = false, want true when --buffered-output is not set")
+	}
+}
+
+func TestBuildCommandBufferedOutputFlagEnabled(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancel()
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--buffered-output", "updates"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() error = %v, want context.Canceled", err)
+	}
+	if !globalConfig.BufferedOutput {
+		t.Error("BufferedOutput = false, want true when --buffered-output is set")
+	}
+	if globalConfig.PreferLiveMode {
+		t.Error("PreferLiveMode = true, want false when --buffered-output is set")
+	}
+}
+
+func TestBuildCommandDisplayModeFlagRemoved(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--display-mode", "buffered", "updates"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected an error for removed --display-mode flag")
+	}
+	if !strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Errorf("unexpected error for removed flag: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -56,6 +56,7 @@ func TestBuildCommandFlags(t *testing.T) {
 		"ssh-passphrase":       false,
 		"debug":                false,
 		"max-concurrent-hosts": false,
+		"display-mode":         false,
 		"skip-hostkey-check":   false,
 	}
 
@@ -76,8 +77,8 @@ func TestBuildCommandFlags(t *testing.T) {
 	}
 
 	// Test that we have the right number of flags
-	if len(cmd.Flags) != 7 {
-		t.Errorf("Expected 7 flags, got %d", len(cmd.Flags))
+	if len(cmd.Flags) != 8 {
+		t.Errorf("Expected 8 flags, got %d", len(cmd.Flags))
 	}
 }
 


### PR DESCRIPTION
Restore the default live display behavior while introducing a new `--buffered-output` command line flag for enhanced control. Align the enroll, export, and updates subcommands with this new display behavior.