### PR TITLE
chore(common/display) Remove FinishError() method since it is only a wrapper

### DIFF
--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -158,15 +158,20 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 	processHost := func(i int, host string) {
 		line := disp.Line(i)
 		displayStepCallback := display.NewStepCallback(line)
-		if err := enroll(ctx, host, cfg, deps, displayStepCallback); err != nil {
+		err := enroll(ctx, host, cfg, deps, displayStepCallback)
+		switch {
+		case errors.Is(err, ssh.ErrConnectionFailed):
+                        line.CompleteStep("❓")
+                        line.Finish("❓", err.Error())
+		case err != nil:
 			line.CompleteStep("❌")
 			line.Finish("❌", fmt.Sprintf("Enrollment failed: %s", err.Error()))
 			errs[i] = err
 			slog.Error("enrollment failed", "host", host, "hostname", cfg.Hostname, "error", err)
-			return
+		default:
+			slog.Info("enrollment completed successfully", "host", host, "hostname", cfg.Hostname)
+			line.Finish("✅", "Enrollment completed successfully")
 		}
-		slog.Info("enrollment completed successfully", "host", host, "hostname", cfg.Hostname)
-		line.Finish("✅", "Enrollment completed successfully")
 	}
 
 	sem := make(chan struct{}, cfg.MaxConcurrentHosts)

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -165,7 +165,7 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
                         line.Finish("❓", err.Error())
 		case err != nil:
 			line.CompleteStep("❌")
-			line.Finish("❌", fmt.Sprintf("Enrollment failed: %s", err.Error()))
+			line.Finish("❌", fmt.Sprintf("Enrollment failed: %v", err))
 			errs[i] = err
 			slog.Error("enrollment failed", "host", host, "hostname", cfg.Hostname, "error", err)
 		default:

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -160,7 +160,7 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 		displayStepCallback := display.NewStepCallback(line)
 		if err := enroll(ctx, host, cfg, deps, displayStepCallback); err != nil {
 			line.CompleteStep("❌")
-			line.FinishError(fmt.Sprintf("Enrollment failed: %s", err.Error()))
+			line.Finish("❌", fmt.Sprintf("Enrollment failed: %s", err.Error()))
 			errs[i] = err
 			slog.Error("enrollment failed", "host", host, "hostname", cfg.Hostname, "error", err)
 			return

--- a/cmd/enroll/enroll.go
+++ b/cmd/enroll/enroll.go
@@ -161,8 +161,8 @@ func runEnrollForHosts(ctx context.Context, hosts []string, cfg EnrollConfig, de
 		err := enroll(ctx, host, cfg, deps, displayStepCallback)
 		switch {
 		case errors.Is(err, ssh.ErrConnectionFailed):
-                        line.CompleteStep("❓")
-                        line.Finish("❓", err.Error())
+			line.CompleteStep("❓")
+			line.Finish("❓", err.Error())
 		case err != nil:
 			line.CompleteStep("❌")
 			line.Finish("❌", fmt.Sprintf("Enrollment failed: %v", err))

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -95,7 +95,7 @@ func runExportForHosts(ctx context.Context, hosts []string, cfg ExportConfig, de
 			line.Finish("❓", err.Error())
 		case err != nil:
 			line.CompleteStep("❌")
-			line.FinishError(err.Error())
+			line.Finish("❌", err.Error())
 			errs[i] = err
 		default:
 			line.Finish("✅", fmt.Sprintf("Configuration exported to %s", filename))

--- a/cmd/updates/updates.go
+++ b/cmd/updates/updates.go
@@ -96,7 +96,7 @@ func runUpdatesForHosts(ctx context.Context, hosts []string, cfg UpdatesConfig, 
 			line.Finish("❓", err.Error())
 		case err != nil:
 			line.CompleteStep("❌")
-			line.FinishError(err.Error())
+			line.Finish("❌", err.Error())
 			errs[i] = err
 		case osStatus == nil:
 			line.Finish("❓", "update applied, status unverified")

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -18,6 +18,12 @@ const (
 	maxHostnameWidth = 20
 )
 
+// singleton guard: only one LiveDisplay may drive liveterm at a time.
+var (
+	singletonMu    sync.Mutex
+	activeLiveDisp *LiveDisplay
+)
+
 // InitOptions configures display initialization parameters.
 type InitOptions struct {
 	// Debug indicates whether --debug is enabled. Debug has priority and disables live mode.
@@ -108,6 +114,7 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 		}
 	}
 }
+
 // renderUnlocked renders the line. The caller must hold h.mu.
 func (h *HostLine) renderUnlocked() string {
 	hostname := formatHostname(h.hostname, h.hostnameWidth)
@@ -152,32 +159,6 @@ func (h *HostLine) render() string {
 	return h.renderUnlocked()
 }
 
-// singleton guard: only one LiveDisplay may drive liveterm at a time.
-var (
-	singletonMu    sync.Mutex
-	activeLiveDisp *LiveDisplay
-)
-
-// LiveDisplay manages per-host live output lines.
-type LiveDisplay struct {
-	lines []*HostLine
-	out   io.Writer
-
-	// liveMode is the effective runtime state after evaluating display mode,
-	// debug, TTY, and any live startup fallback (for example singleton contention).
-	liveMode bool
-
-	// isTTY is detected once at construction time and does not change.
-	isTTY bool
-	// debug indicates whether --debug is enabled. Debug has priority and disables live mode.
-	debug bool
-	// concurrent enables ordered buffering when live mode is off.
-	concurrent bool
-
-	// pendingLines holds one rendered final line per host in concurrent non-live mode.
-	pendingLines []string
-}
-
 // New creates and initializes a LiveDisplay.
 // It applies display mode policy, configures concurrency behavior, and starts
 // live rendering when applicable.
@@ -214,12 +195,73 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	return d
 }
 
+// LiveDisplay manages per-host live output lines.
+type LiveDisplay struct {
+	lines []*HostLine
+	out   io.Writer
+
+	// liveMode is the effective runtime state after evaluating display mode,
+	// debug, TTY, and any live startup fallback (for example singleton contention).
+	liveMode bool
+
+	// isTTY is detected once at construction time and does not change.
+	isTTY bool
+	// debug indicates whether --debug is enabled. Debug has priority and disables live mode.
+	debug bool
+	// concurrent enables ordered buffering when live mode is off.
+	concurrent bool
+
+	// pendingLines holds one rendered final line per host in concurrent non-live mode.
+	pendingLines []string
+}
+
+// Line returns the HostLine for the i-th host (0-indexed).
+func (d *LiveDisplay) Line(i int) *HostLine {
+	return d.lines[i]
+}
+
+// LiveMode reports whether the display is effectively running in live mode.
+func (d *LiveDisplay) LiveMode() bool {
+	return d.liveMode
+}
+
+// LogWriter returns a writer safe to use for permanent log output while the
+// live display is active.
+func (d *LiveDisplay) LogWriter() io.Writer {
+	if !d.liveMode {
+		return nil
+	}
+	return liveterm.Bypass()
+}
+
+// Stop finalises output. In live mode it stops liveterm. In concurrent non-live
+// mode it flushes all buffered host lines to out in host-list order, so that
+// goroutines that finish at different times still produce deterministic output.
+func (d *LiveDisplay) Stop() {
+	if d.liveMode {
+		defer d.release()
+		if err := liveterm.Stop(false); err != nil {
+			slog.Warn("display: failed to stop live terminal", "error", err)
+		}
+		return
+	}
+	for i, line := range d.pendingLines {
+		if line == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(d.out, "%s\n", line); err != nil {
+			slog.Warn("display: failed to write host line", "error", err, "line_index", i, "hostname", d.lines[i].hostname)
+		}
+	}
+}
+
 // setConcurrent marks the display as serving concurrent host processing.
 func (d *LiveDisplay) setConcurrent(concurrent bool) {
 	d.concurrent = concurrent
 	d.applyConcurrencyBuffering()
 }
 
+// applyMode applies the live mode policy based on the current settings and environment.
 func (d *LiveDisplay) applyMode(preferLiveMode bool) {
 	// Debug flag has priority: if --debug is enabled, always disable live mode
 	// to keep output clean and deterministic for log analysis.
@@ -248,13 +290,6 @@ func (d *LiveDisplay) applyConcurrencyBuffering() {
 	d.clearNonLive()
 }
 
-func (d *LiveDisplay) setLiveMode(enabled bool) {
-	d.liveMode = enabled
-	for _, l := range d.lines {
-		l.liveMode = enabled
-	}
-}
-
 // clearNonLive removes any non-live buffering state so sequential mode writes
 // each line immediately instead of buffering for Stop.
 func (d *LiveDisplay) clearNonLive() {
@@ -275,23 +310,49 @@ func (d *LiveDisplay) initNonLive() {
 	}
 }
 
-// Line returns the HostLine for the i-th host (0-indexed).
-func (d *LiveDisplay) Line(i int) *HostLine {
-	return d.lines[i]
-}
-
-// LiveMode reports whether the display is effectively running in live mode.
-func (d *LiveDisplay) LiveMode() bool {
-	return d.liveMode
-}
-
-// LogWriter returns a writer safe to use for permanent log output while the
-// live display is active.
-func (d *LiveDisplay) LogWriter() io.Writer {
-	if !d.liveMode {
-		return nil
+// release clears the singleton slot if this display holds it.
+func (d *LiveDisplay) release() {
+	singletonMu.Lock()
+	defer singletonMu.Unlock()
+	if activeLiveDisp == d {
+		activeLiveDisp = nil
 	}
-	return liveterm.Bypass()
+}
+
+// renderLines returns all host lines for liveterm to display.
+// This implementation atomically captures the state of all lines to prevent race
+// conditions where intermediate states (e.g., ⏳ Connecting…) are visible alongside
+// final states (e.g., ✅ or ❓). By acquiring all locks in order before rendering,
+// we ensure the snapshot is consistent and matches the moment in time it was taken.
+// WARNING: removing the locks or changing the locking strategy may cause race conditions
+// WARNING: where intermediate states are rendered alongside final states, leading to confusing output.
+// WARNING: Do not modify without careful consideration.
+func (d *LiveDisplay) renderLines() []string {
+	// Acquire all locks in index order to prevent deadlock and capture an atomic snapshot.
+	for _, l := range d.lines {
+		l.mu.Lock()
+	}
+	defer func() {
+		// Release all locks in reverse order to maintain consistency.
+		for i := len(d.lines) - 1; i >= 0; i-- {
+			d.lines[i].mu.Unlock()
+		}
+	}()
+
+	// Now render all lines while holding all locks; no state can change during this render.
+	out := make([]string, len(d.lines))
+	for i, l := range d.lines {
+		out[i] = l.renderUnlocked()
+	}
+	return out
+}
+
+// setLiveMode sets the liveMode flag and updates all HostLines accordingly.
+func (d *LiveDisplay) setLiveMode(enabled bool) {
+	d.liveMode = enabled
+	for _, l := range d.lines {
+		l.liveMode = enabled
+	}
 }
 
 // start begins live output. In fallback mode this is a no-op.
@@ -338,64 +399,7 @@ func (d *LiveDisplay) tryClaim() bool {
 	return true
 }
 
-// release clears the singleton slot if this display holds it.
-func (d *LiveDisplay) release() {
-	singletonMu.Lock()
-	defer singletonMu.Unlock()
-	if activeLiveDisp == d {
-		activeLiveDisp = nil
-	}
-}
-
-// Stop finalises output. In live mode it stops liveterm. In concurrent non-live
-// mode it flushes all buffered host lines to out in host-list order, so that
-// goroutines that finish at different times still produce deterministic output.
-func (d *LiveDisplay) Stop() {
-	if d.liveMode {
-		defer d.release()
-		if err := liveterm.Stop(false); err != nil {
-			slog.Warn("display: failed to stop live terminal", "error", err)
-		}
-		return
-	}
-	for i, line := range d.pendingLines {
-		if line == "" {
-			continue
-		}
-		if _, err := fmt.Fprintf(d.out, "%s\n", line); err != nil {
-			slog.Warn("display: failed to write host line", "error", err, "line_index", i, "hostname", d.lines[i].hostname)
-		}
-	}
-}
-
-// renderLines returns all host lines for liveterm to display.
-// This implementation atomically captures the state of all lines to prevent race
-// conditions where intermediate states (e.g., ⏳ Connecting…) are visible alongside
-// final states (e.g., ✅ or ❓). By acquiring all locks in order before rendering,
-// we ensure the snapshot is consistent and matches the moment in time it was taken.
-// WARNING: removing the locks or changing the locking strategy may cause race conditions
-// WARNING: where intermediate states are rendered alongside final states, leading to confusing output.
-// WARNING: Do not modify without careful consideration.
-func (d *LiveDisplay) renderLines() []string {
-	// Acquire all locks in index order to prevent deadlock and capture an atomic snapshot.
-	for _, l := range d.lines {
-		l.mu.Lock()
-	}
-	defer func() {
-		// Release all locks in reverse order to maintain consistency.
-		for i := len(d.lines) - 1; i >= 0; i-- {
-			d.lines[i].mu.Unlock()
-		}
-	}()
-
-	// Now render all lines while holding all locks; no state can change during this render.
-	out := make([]string, len(d.lines))
-	for i, l := range d.lines {
-		out[i] = l.renderUnlocked()
-	}
-	return out
-}
-
+// Helper to compute hostname column width based on the longest hostname, with min and max bounds.
 func computeHostnameWidth(hosts []string) int {
 	maxLen := 0
 	for _, host := range hosts {
@@ -413,6 +417,7 @@ func computeHostnameWidth(hosts []string) int {
 	return maxLen
 }
 
+// helper to format hostname with fixed width and truncation if needed, to keep display aligned.
 func formatHostname(hostname string, width int) string {
 	if width <= 0 {
 		return hostname

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -187,10 +187,15 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 		}
 	}
 
-	// Centralize live preference and concurrency setup in one place so constructor and
-	// runtime behavior match.
-	d.applyMode(opts.PreferLiveMode)
-	d.setConcurrent(opts.Concurrent)
+	// Finalize live and concurrency flags first, then reconcile buffering once so
+	// initialization does not perform redundant setup passes.
+	if d.debug {
+		d.setLiveMode(false)
+	} else {
+		d.setLiveMode(opts.PreferLiveMode && d.isTTY)
+	}
+	d.concurrent = opts.Concurrent
+	d.applyConcurrencyBuffering()
 	d.initLiveMode()
 
 	return d
@@ -251,27 +256,6 @@ func (d *LiveDisplay) Stop() {
 	}
 }
 
-// setConcurrent marks the display as serving concurrent host processing.
-func (d *LiveDisplay) setConcurrent(concurrent bool) {
-	d.concurrent = concurrent
-	d.applyConcurrencyBuffering()
-}
-
-// applyMode applies the live mode policy based on the current settings and environment.
-func (d *LiveDisplay) applyMode(preferLiveMode bool) {
-	// Debug flag has priority: if --debug is enabled, always disable live mode
-	// to keep output clean and deterministic for log analysis.
-	if d.debug {
-		d.setLiveMode(false)
-	} else {
-		// Live mode is enabled only when preferred and when a TTY is available.
-		shouldLive := preferLiveMode && d.isTTY
-		d.setLiveMode(shouldLive)
-	}
-
-	d.applyConcurrencyBuffering()
-}
-
 // applyConcurrencyBuffering configures whether host lines are buffered until
 // Stop based on current concurrency + effective live mode.
 func (d *LiveDisplay) applyConcurrencyBuffering() {
@@ -324,7 +308,7 @@ func (d *LiveDisplay) initLiveMode() {
 
 // initNonLive allocates d.pendingLines and wires each HostLine.pending to it.
 // Called during initial construction when the display starts in non-live mode,
-// and whenever a live-mode display transitions to non-live mode via Start's
+// and whenever a live-mode display transitions to non-live mode via initLiveMode's
 // fallback paths (singleton contention or liveterm.Start failure).
 func (d *LiveDisplay) initNonLive() {
 	d.pendingLines = make([]string, len(d.lines))

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/term"
 )
 
+// Constants for hostname column width limits to keep display aligned and prevent overflow.
 const (
 	minHostnameWidth = 10
 	maxHostnameWidth = 20
@@ -34,11 +35,6 @@ type InitOptions struct {
 	Concurrent bool
 }
 
-// completedStep records an already-finished step with its emoticon.
-type completedStep struct {
-	emoji string
-}
-
 // HostLine tracks the display state for a single host.
 type HostLine struct {
 	mu            sync.Mutex
@@ -54,6 +50,11 @@ type HostLine struct {
 	done          bool
 	finalMessage  string // set by Finish; does not include the hostname or overall emoji
 	liveMode      bool
+}
+
+// completedStep records an already-finished step with its emoticon.
+type completedStep struct {
+	emoji string
 }
 
 // StepCallback is used to update step display for a host.
@@ -190,7 +191,7 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	// runtime behavior match.
 	d.applyMode(opts.PreferLiveMode)
 	d.setConcurrent(opts.Concurrent)
-	d.start()
+	d.initLiveMode()
 
 	return d
 }
@@ -218,11 +219,6 @@ type LiveDisplay struct {
 // Line returns the HostLine for the i-th host (0-indexed).
 func (d *LiveDisplay) Line(i int) *HostLine {
 	return d.lines[i]
-}
-
-// LiveMode reports whether the display is effectively running in live mode.
-func (d *LiveDisplay) LiveMode() bool {
-	return d.liveMode
 }
 
 // LogWriter returns a writer safe to use for permanent log output while the
@@ -287,15 +283,42 @@ func (d *LiveDisplay) applyConcurrencyBuffering() {
 		}
 		return
 	}
-	d.clearNonLive()
-}
-
-// clearNonLive removes any non-live buffering state so sequential mode writes
-// each line immediately instead of buffering for Stop.
-func (d *LiveDisplay) clearNonLive() {
 	d.pendingLines = nil
 	for _, l := range d.lines {
 		l.pending = nil
+	}
+}
+
+// initLiveMode begins live output. In fallback mode this is a no-op.
+// Only one LiveDisplay may be in live mode at a time: if another display is
+// already active, initLiveMode falls back to plain-text mode so that the existing
+// liveterm instance is not disturbed.
+func (d *LiveDisplay) initLiveMode() {
+	if !d.liveMode {
+		return
+	}
+
+	// Try to claim the singleton slot. The lock is released before calling
+	// liveterm.Start so the refresh goroutine can acquire it if needed.
+	if !d.tryClaim() {
+		// Another display is already running; fall back to plain text.
+		d.setLiveMode(false)
+		if d.concurrent {
+			d.initNonLive()
+		}
+		return
+	}
+
+	liveterm.RefreshInterval = 100 * time.Millisecond
+	liveterm.Output = d.out
+	liveterm.SetMultiLinesUpdateFx(d.renderLines)
+	if err := liveterm.Start(); err != nil {
+		// If liveterm fails to start (e.g. no real TTY despite fd check), fall back.
+		d.release()
+		d.setLiveMode(false)
+		if d.concurrent {
+			d.initNonLive()
+		}
 	}
 }
 
@@ -352,39 +375,6 @@ func (d *LiveDisplay) setLiveMode(enabled bool) {
 	d.liveMode = enabled
 	for _, l := range d.lines {
 		l.liveMode = enabled
-	}
-}
-
-// start begins live output. In fallback mode this is a no-op.
-// Only one LiveDisplay may be in live mode at a time: if another display is
-// already active, start falls back to plain-text mode so that the existing
-// liveterm instance is not disturbed.
-func (d *LiveDisplay) start() {
-	if !d.liveMode {
-		return
-	}
-
-	// Try to claim the singleton slot. The lock is released before calling
-	// liveterm.Start so the refresh goroutine can acquire it if needed.
-	if !d.tryClaim() {
-		// Another display is already running; fall back to plain text.
-		d.setLiveMode(false)
-		if d.concurrent {
-			d.initNonLive()
-		}
-		return
-	}
-
-	liveterm.RefreshInterval = 100 * time.Millisecond
-	liveterm.Output = d.out
-	liveterm.SetMultiLinesUpdateFx(d.renderLines)
-	if err := liveterm.Start(); err != nil {
-		// If liveterm fails to start (e.g. no real TTY despite fd check), fall back.
-		d.release()
-		d.setLiveMode(false)
-		if d.concurrent {
-			d.initNonLive()
-		}
 	}
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -108,12 +108,6 @@ func (h *HostLine) Finish(overallEmoji, message string) {
 		}
 	}
 }
-
-// FinishError marks the line as done with ❌ and the given error message.
-func (h *HostLine) FinishError(msg string) {
-	h.Finish("❌", msg)
-}
-
 // renderUnlocked renders the line. The caller must hold h.mu.
 func (h *HostLine) renderUnlocked() string {
 	hostname := formatHostname(h.hostname, h.hostnameWidth)

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -25,25 +25,21 @@ func newLiveModeDisplay(out *bytes.Buffer, hosts []string) *LiveDisplay {
 	return d
 }
 
-func TestPreferLiveKeepsLiveWhenCapable(t *testing.T) {
+func TestPreferLiveFallsBackWhenTTYUnavailable(t *testing.T) {
 	var buf bytes.Buffer
 	d := New(&buf, []string{"router1"}, InitOptions{Debug: false, PreferLiveMode: true, Concurrent: true})
-	d.isTTY = true
-	d.applyMode(true)
 
-	if !d.liveMode {
-		t.Fatal("expected live mode to stay enabled in concurrent auto mode on a live-capable terminal")
+	if d.liveMode {
+		t.Fatal("expected live mode to be disabled when output is not a TTY")
 	}
-	if d.pendingLines != nil {
-		t.Fatalf("expected no buffered pending lines in concurrent auto live mode, got %#v", d.pendingLines)
+	if d.pendingLines == nil || len(d.pendingLines) != 1 {
+		t.Fatalf("expected pending lines buffer of size 1 in concurrent non-live mode, got %#v", d.pendingLines)
 	}
 }
 
 func TestBufferedPreferenceForcesConcurrentBuffering(t *testing.T) {
 	var buf bytes.Buffer
 	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, PreferLiveMode: false, Concurrent: true})
-	d.isTTY = true
-	d.applyMode(false)
 
 	if d.liveMode {
 		t.Fatal("expected live mode to be disabled in buffered mode")

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -136,22 +136,22 @@ func TestFinishFallback(t *testing.T) {
 	}
 }
 
-func TestFinishErrorFallback(t *testing.T) {
+func TestFinishWithErrorFallback(t *testing.T) {
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, []string{"badrouter.example.com"})
 	l := d.Line(0)
 
 	l.UpdateStep("⏳", "connecting…")
 	l.CompleteStep("⏳")
-	l.FinishError("updates failed: ssh: connect: timeout")
+	l.Finish("❌", "updates failed: ssh: connect: timeout")
 
-	// In non-concurrent non-live mode, FinishError writes immediately to out.
+	// In non-concurrent non-live mode, Finish writes immediately to out.
 	output := buf.String()
 	if !strings.Contains(output, "❌") {
-		t.Errorf("FinishError() output = %q, want ❌", output)
+		t.Errorf("Finish(❌, ...) output = %q, want ❌", output)
 	}
 	if !strings.Contains(output, "badrouter.example.c…") {
-		t.Errorf("FinishError() output = %q, want truncated hostname", output)
+		t.Errorf("Finish(❌, ...) output = %q, want truncated hostname", output)
 	}
 	d.Stop() // no-op for sequential non-live mode
 }
@@ -377,7 +377,7 @@ func TestRenderFormatConsistency(t *testing.T) {
 			name: "done error",
 			setup: func(l *HostLine) {
 				l.CompleteStep("❌")
-				l.FinishError("updates failed: timeout")
+				l.Finish("❌", "updates failed: timeout")
 			},
 			wantPrefix:   "❌",
 			wantContains: []string{"router.example.com", "❌", "updates failed: timeout"},

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -37,6 +37,23 @@ func TestPreferLiveFallsBackWhenTTYUnavailable(t *testing.T) {
 	}
 }
 
+func TestPreferLiveEnablesLiveModeWhenTTYAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, PreferLiveMode: true, Concurrent: true})
+
+	d.isTTY = true
+	d.debug = false
+	d.setLiveMode(true)
+
+	if !d.liveMode {
+		t.Fatal("expected live mode to be enabled when PreferLiveMode is true and output is a TTY")
+	}
+	for i, l := range d.lines {
+		if !l.liveMode {
+			t.Fatalf("expected line %d to also be in live mode", i)
+		}
+	}
+}
 func TestBufferedPreferenceForcesConcurrentBuffering(t *testing.T) {
 	var buf bytes.Buffer
 	d := New(&buf, []string{"router1", "router2"}, InitOptions{Debug: false, PreferLiveMode: false, Concurrent: true})

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -439,10 +439,10 @@ func TestSingletonFallback(t *testing.T) {
 
 	// A second display in live mode should fall back to plain text.
 	second := newLiveModeDisplay(&buf2, []string{"router2"})
-	second.start() // should detect activeLiveDisp != nil and fall back
+	second.initLiveMode() // should detect activeLiveDisp != nil and fall back
 
 	if second.liveMode {
-		t.Error("second start() should have fallen back to plain text when a display is already active")
+		t.Error("second initLiveMode() should have fallen back to plain text when a display is already active")
 	}
 	for _, l := range second.lines {
 		if l.liveMode {


### PR DESCRIPTION
Changes:
* Remove the `FinishError()` method as it served only as a wrapper, and replace its usage with `Finish()` in relevant files.
* Reorganize the content of the display package for better clarity and maintainability.
* Rationalize internal methods and helpers
* [BOYSCOUT] align enroll subcommand error management with other subcommands