### PR TITLE
feat(common/display) Improve console output layout in having better separation between logs and hosts status

### DIFF
--- a/common/display/display.go
+++ b/common/display/display.go
@@ -58,7 +58,7 @@ type completedStep struct {
 }
 
 // logWriterWithSeparator wraps a writer and tracks whether any write has occurred.
-// On the first write it emits a LOGS header line at the current terminal width so
+// On the first write it emits a LOGS header line so
 // the log stream is visually labelled. renderLines uses HasWritten to decide
 // whether to add a blank separator line between the log stream and the host status block.
 type logWriterWithSeparator struct {

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -464,14 +464,13 @@ func termWidth(fd int) int {
 // columns wide. If width is too small to accommodate the label section, it
 // returns the minimal "── LABEL" form and may therefore exceed width.
 func separatorLine(label string, width int) string {
-	// prefix = "── " (3 cols) + label + " " (1 col)
-	prefix := "── " + label + " "
-	prefixCols := 3 + len([]rune(label)) + 1
-	trailing := width - prefixCols
-	if trailing < 0 {
-		return "── " + label
+	base := "── " + label
+	baseCols := 3 + len([]rune(label))
+	trailing := width - baseCols - 1 // account for the space before trailing dashes
+	if trailing <= 0 {
+		return base
 	}
-	return prefix + strings.Repeat("─", trailing)
+	return base + " " + strings.Repeat("─", trailing)
 }
 
 // Helper to compute hostname column width based on the longest hostname, with min and max bounds.

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -389,7 +389,7 @@ func (d *LiveDisplay) renderLines() []string {
 	if d.logWriter != nil && d.logWriter.HasWritten() {
 		out = append(out, "")
 	}
-	out = append(out, "── HOST STATUS ──────────────────────────")
+	out = append(out, "── HOSTS STATUS ─────────────────────────")
 	for _, l := range d.lines {
 		out = append(out, l.renderUnlocked())
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -23,6 +23,7 @@ const (
 var (
 	singletonMu    sync.Mutex
 	activeLiveDisp *LiveDisplay
+	startLiveTerm  = liveterm.Start
 )
 
 // InitOptions configures display initialization parameters.
@@ -344,7 +345,7 @@ func (d *LiveDisplay) initLiveMode() {
 	liveterm.RefreshInterval = 100 * time.Millisecond
 	liveterm.Output = d.out
 	liveterm.SetMultiLinesUpdateFx(d.renderLines)
-	if err := liveterm.Start(); err != nil {
+	if err := startLiveTerm(); err != nil {
 		// If liveterm fails to start (e.g. no real TTY despite fd check), fall back.
 		d.release()
 		d.setLiveMode(false)

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -459,9 +459,10 @@ func termWidth(fd int) int {
 	return width
 }
 
-// separatorLine builds a full-width separator of the form "── LABEL ──────...".
-// The line is exactly width terminal columns wide. If width is too small to
-// accommodate the label, trailing dashes are omitted.
+// separatorLine builds a separator of the form "── LABEL ──────...".
+// When width is large enough, the returned line is exactly width terminal
+// columns wide. If width is too small to accommodate the label section, it
+// returns the minimal "── LABEL" form and may therefore exceed width.
 func separatorLine(label string, width int) string {
 	// prefix = "── " (3 cols) + label + " " (1 col)
 	prefix := "── " + label + " "

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -458,7 +458,7 @@ func separatorLine(label string, width int) string {
 	prefix := "── " + label + " "
 	prefixCols := 3 + len([]rune(label)) + 1
 	trailing := width - prefixCols
-	if trailing <= 0 {
+	if trailing < 0 {
 		return "── " + label
 	}
 	return prefix + strings.Repeat("─", trailing)

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -80,7 +80,7 @@ func (w *logWriter) Write(p []byte) (int, error) {
 			return n, err
 		}
 		if n != len(header) {
-			return n, io.ErrShortWrite
+			return 0, io.ErrShortWrite
 		}
 		w.hasWritten = true
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -277,7 +277,9 @@ func (d *LiveDisplay) LogWriter() io.Writer {
 	if !d.liveMode {
 		return nil
 	}
-	d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass(), outFd: d.outFd}
+	if d.logWriter == nil {
+		d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass(), outFd: d.outFd}
+	}
 	return d.logWriter
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -414,8 +414,8 @@ func (d *LiveDisplay) renderLines() []string {
 	// Now render all lines while holding all locks; no state can change during this render.
 	// Prepend a blank separator line when logs have been written, so the host status
 	// block is visually distinct from the bypass log stream above it.
-	// We need to allocate the output slice with enough capacity for all lines plus the optional separator,
-	// to avoid reallocations during appends which could cause inconsistent snapshots if the underlying array is shared.
+	// Allocate enough capacity for all lines plus the optional separator up front
+	// to reduce append reallocations and avoid extra allocations in this hot refresh path.
 	var out = make([]string, 0, len(d.lines)+2)
 	if d.logWriter != nil && d.logWriter.HasWritten() {
 		out = append(out, "")

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -58,24 +58,24 @@ type completedStep struct {
 }
 
 // logWriterWithSeparator wraps a writer and tracks whether any write has occurred.
-// On the first write it emits a LOGS header line so the log stream is visually
-// labelled. renderLines uses HasWritten to decide whether to add a blank separator
-// line between the log stream and the host status block.
+// On the first write it emits a LOGS header line at the current terminal width so
+// the log stream is visually labelled. renderLines uses HasWritten to decide
+// whether to add a blank separator line between the log stream and the host status block.
 type logWriterWithSeparator struct {
 	once       sync.Once
 	mu         sync.Mutex
 	base       io.Writer
+	outFd      int // file descriptor for terminal width queries; -1 for no TTY
 	hasWritten bool
 }
-
-const logsHeader = "── LOGS ───────────────────────────────────\n"
 
 func (w *logWriterWithSeparator) Write(p []byte) (int, error) {
 	w.once.Do(func() {
 		w.mu.Lock()
 		w.hasWritten = true
 		w.mu.Unlock()
-		w.base.Write([]byte(logsHeader)) //nolint:errcheck
+		header := separatorLine("LOGS", termWidth(w.outFd)) + "\n"
+		w.base.Write([]byte(header)) //nolint:errcheck
 	})
 	return w.base.Write(p)
 }
@@ -194,14 +194,20 @@ func (h *HostLine) render() string {
 // live rendering when applicable.
 func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	isTTY := false
+	outFd := -1
 	if f, ok := out.(*os.File); ok {
-		isTTY = term.IsTerminal(int(f.Fd()))
+		fd := int(f.Fd())
+		if term.IsTerminal(fd) {
+			isTTY = true
+			outFd = fd
+		}
 	}
 	hostnameWidth := computeHostnameWidth(hosts)
 
 	d := &LiveDisplay{
 		lines: make([]*HostLine, len(hosts)),
 		isTTY: isTTY,
+		outFd: outFd,
 		debug: opts.Debug,
 		out:   out,
 	}
@@ -235,6 +241,10 @@ type LiveDisplay struct {
 	lines []*HostLine
 	out   io.Writer
 
+	// outFd is the file descriptor of out when it is a queryable TTY; -1 otherwise.
+	// Used to query terminal width dynamically for separator lines.
+	outFd int
+
 	// logWriter tracks whether any log output has been written via LogWriter.
 	// Used by renderLines to decide whether to prepend a blank separator line.
 	logWriter *logWriterWithSeparator
@@ -267,7 +277,7 @@ func (d *LiveDisplay) LogWriter() io.Writer {
 	if !d.liveMode {
 		return nil
 	}
-	d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass()}
+	d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass(), outFd: d.outFd}
 	return d.logWriter
 }
 
@@ -389,7 +399,7 @@ func (d *LiveDisplay) renderLines() []string {
 	if d.logWriter != nil && d.logWriter.HasWritten() {
 		out = append(out, "")
 	}
-	out = append(out, "── HOSTS STATUS ─────────────────────────")
+	out = append(out, separatorLine("HOSTS STATUS", termWidth(d.outFd)))
 	for _, l := range d.lines {
 		out = append(out, l.renderUnlocked())
 	}
@@ -413,6 +423,33 @@ func (d *LiveDisplay) tryClaim() bool {
 	}
 	activeLiveDisp = d
 	return true
+}
+
+// termWidth returns the current terminal width for the given file descriptor.
+// Returns 80 if fd is negative or the terminal size cannot be determined.
+func termWidth(fd int) int {
+	if fd < 0 {
+		return 80
+	}
+	width, _, err := term.GetSize(fd)
+	if err != nil || width <= 0 {
+		return 80
+	}
+	return width
+}
+
+// separatorLine builds a full-width separator of the form "── LABEL ──────...".
+// The line is exactly width terminal columns wide. If width is too small to
+// accommodate the label, trailing dashes are omitted.
+func separatorLine(label string, width int) string {
+	// prefix = "── " (3 cols) + label + " " (1 col)
+	prefix := "── " + label + " "
+	prefixCols := 3 + len([]rune(label)) + 1
+	trailing := width - prefixCols
+	if trailing <= 0 {
+		return "── " + label
+	}
+	return prefix + strings.Repeat("─", trailing)
 }
 
 // Helper to compute hostname column width based on the longest hostname, with min and max bounds.

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -74,7 +74,7 @@ func (w *logWriterWithSeparator) Write(p []byte) (int, error) {
 		w.mu.Lock()
 		w.hasWritten = true
 		w.mu.Unlock()
-		header := separatorLine("LOGS", termWidth(w.outFd)) + "\n"
+		header := "── LOGS\n"
 		w.base.Write([]byte(header)) //nolint:errcheck
 	})
 	return w.base.Write(p)

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -63,7 +63,6 @@ type completedStep struct {
 // the log stream is visually labelled. renderLines uses HasWritten to decide
 // whether to add a blank separator line between the log stream and the host status block.
 type logWriter struct {
-	once       sync.Once
 	mu         sync.Mutex
 	base       io.Writer
 	outFd      int // file descriptor for terminal width queries; -1 for no TTY
@@ -71,13 +70,21 @@ type logWriter struct {
 }
 
 func (w *logWriter) Write(p []byte) (int, error) {
-	w.once.Do(func() {
-		w.mu.Lock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if !w.hasWritten {
+		header := []byte("── LOGS\n")
+		n, err := w.base.Write(header)
+		if err != nil {
+			return 0, err
+		}
+		if n != len(header) {
+			return 0, io.ErrShortWrite
+		}
 		w.hasWritten = true
-		w.mu.Unlock()
-		header := "── LOGS\n"
-		w.base.Write([]byte(header)) //nolint:errcheck
-	})
+	}
+
 	return w.base.Write(p)
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -414,7 +414,9 @@ func (d *LiveDisplay) renderLines() []string {
 	// Now render all lines while holding all locks; no state can change during this render.
 	// Prepend a blank separator line when logs have been written, so the host status
 	// block is visually distinct from the bypass log stream above it.
-	var out []string
+	// We need to allocate the output slice with enough capacity for all lines plus the optional separator,
+	// to avoid reallocations during appends which could cause inconsistent snapshots if the underlying array is shared.
+	var out = make([]string, 0, len(d.lines)+2)
 	if d.logWriter != nil && d.logWriter.HasWritten() {
 		out = append(out, "")
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -77,10 +77,10 @@ func (w *logWriter) Write(p []byte) (int, error) {
 		header := []byte("── LOGS\n")
 		n, err := w.base.Write(header)
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 		if n != len(header) {
-			return 0, io.ErrShortWrite
+			return n, io.ErrShortWrite
 		}
 		w.hasWritten = true
 	}

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -232,6 +232,7 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	}
 	d.concurrent = opts.Concurrent
 	d.applyConcurrencyBuffering()
+	d.initLiveLogWriter()
 	d.initLiveMode()
 
 	return d
@@ -277,9 +278,6 @@ func (d *LiveDisplay) Line(i int) *HostLine {
 func (d *LiveDisplay) LogWriter() io.Writer {
 	if !d.liveMode {
 		return nil
-	}
-	if d.logWriter == nil {
-		d.logWriter = &logWriter{base: liveterm.Bypass(), outFd: d.outFd}
 	}
 	return d.logWriter
 }
@@ -352,6 +350,17 @@ func (d *LiveDisplay) initLiveMode() {
 		if d.concurrent {
 			d.initNonLive()
 		}
+	}
+}
+
+// initLiveLogWriter eagerly initializes the live log writer.
+// It is a no-op when live mode is disabled.
+func (d *LiveDisplay) initLiveLogWriter() {
+	if !d.liveMode {
+		return
+	}
+	if d.logWriter == nil {
+		d.logWriter = &logWriter{base: liveterm.Bypass(), outFd: d.outFd}
 	}
 }
 

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -239,8 +239,8 @@ func New(out io.Writer, hosts []string, opts InitOptions) *LiveDisplay {
 	}
 	d.concurrent = opts.Concurrent
 	d.applyConcurrencyBuffering()
-	d.initLiveLogWriter()
 	d.initLiveMode()
+	d.initLiveLogWriter()
 
 	return d
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -57,6 +57,35 @@ type completedStep struct {
 	emoji string
 }
 
+// logWriterWithSeparator wraps a writer and tracks whether any write has occurred.
+// On the first write it emits a LOGS header line so the log stream is visually
+// labelled. renderLines uses HasWritten to decide whether to add a blank separator
+// line between the log stream and the host status block.
+type logWriterWithSeparator struct {
+	once       sync.Once
+	mu         sync.Mutex
+	base       io.Writer
+	hasWritten bool
+}
+
+const logsHeader = "── LOGS ───────────────────────────────────\n"
+
+func (w *logWriterWithSeparator) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		w.mu.Lock()
+		w.hasWritten = true
+		w.mu.Unlock()
+		w.base.Write([]byte(logsHeader)) //nolint:errcheck
+	})
+	return w.base.Write(p)
+}
+
+func (w *logWriterWithSeparator) HasWritten() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.hasWritten
+}
+
 // StepCallback is used to update step display for a host.
 type StepCallback func(emoji string, message string)
 
@@ -206,6 +235,10 @@ type LiveDisplay struct {
 	lines []*HostLine
 	out   io.Writer
 
+	// logWriter tracks whether any log output has been written via LogWriter.
+	// Used by renderLines to decide whether to prepend a blank separator line.
+	logWriter *logWriterWithSeparator
+
 	// liveMode is the effective runtime state after evaluating display mode,
 	// debug, TTY, and any live startup fallback (for example singleton contention).
 	liveMode bool
@@ -227,12 +260,15 @@ func (d *LiveDisplay) Line(i int) *HostLine {
 }
 
 // LogWriter returns a writer safe to use for permanent log output while the
-// live display is active.
+// live display is active. The returned writer tracks whether anything has been
+// written so that renderLines can insert a blank separator line between the log
+// stream and the host status block.
 func (d *LiveDisplay) LogWriter() io.Writer {
 	if !d.liveMode {
 		return nil
 	}
-	return liveterm.Bypass()
+	d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass()}
+	return d.logWriter
 }
 
 // Stop finalises output. In live mode it stops liveterm. In concurrent non-live
@@ -347,9 +383,15 @@ func (d *LiveDisplay) renderLines() []string {
 	}()
 
 	// Now render all lines while holding all locks; no state can change during this render.
-	out := make([]string, len(d.lines))
-	for i, l := range d.lines {
-		out[i] = l.renderUnlocked()
+	// Prepend a blank separator line when logs have been written, so the host status
+	// block is visually distinct from the bypass log stream above it.
+	var out []string
+	if d.logWriter != nil && d.logWriter.HasWritten() {
+		out = append(out, "")
+	}
+	out = append(out, "── HOST STATUS ──────────────────────────")
+	for _, l := range d.lines {
+		out = append(out, l.renderUnlocked())
 	}
 	return out
 }

--- a/common/display/display.go
+++ b/common/display/display.go
@@ -58,11 +58,11 @@ type completedStep struct {
 	emoji string
 }
 
-// logWriterWithSeparator wraps a writer and tracks whether any write has occurred.
+// logWriter wraps a writer and tracks whether any write has occurred.
 // On the first write it emits a LOGS header line so
 // the log stream is visually labelled. renderLines uses HasWritten to decide
 // whether to add a blank separator line between the log stream and the host status block.
-type logWriterWithSeparator struct {
+type logWriter struct {
 	once       sync.Once
 	mu         sync.Mutex
 	base       io.Writer
@@ -70,7 +70,7 @@ type logWriterWithSeparator struct {
 	hasWritten bool
 }
 
-func (w *logWriterWithSeparator) Write(p []byte) (int, error) {
+func (w *logWriter) Write(p []byte) (int, error) {
 	w.once.Do(func() {
 		w.mu.Lock()
 		w.hasWritten = true
@@ -81,7 +81,7 @@ func (w *logWriterWithSeparator) Write(p []byte) (int, error) {
 	return w.base.Write(p)
 }
 
-func (w *logWriterWithSeparator) HasWritten() bool {
+func (w *logWriter) HasWritten() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.hasWritten
@@ -248,7 +248,7 @@ type LiveDisplay struct {
 
 	// logWriter tracks whether any log output has been written via LogWriter.
 	// Used by renderLines to decide whether to prepend a blank separator line.
-	logWriter *logWriterWithSeparator
+	logWriter *logWriter
 
 	// liveMode is the effective runtime state after evaluating display mode,
 	// debug, TTY, and any live startup fallback (for example singleton contention).
@@ -279,7 +279,7 @@ func (d *LiveDisplay) LogWriter() io.Writer {
 		return nil
 	}
 	if d.logWriter == nil {
-		d.logWriter = &logWriterWithSeparator{base: liveterm.Bypass(), outFd: d.outFd}
+		d.logWriter = &logWriter{base: liveterm.Bypass(), outFd: d.outFd}
 	}
 	return d.logWriter
 }

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -784,7 +784,7 @@ func TestSeparatorLine(t *testing.T) {
 		wantLen      int // expected rune length of output
 	}{
 		{label: "LOGS", width: 80, wantContains: "LOGS", wantLen: 80},
-		{label: "HOST STATUS", width: 80, wantContains: "HOST STATUS", wantLen: 80},
+		{label: "HOSTS STATUS", width: 80, wantContains: "HOSTS STATUS", wantLen: 80},
 		{label: "LOGS", width: 40, wantContains: "LOGS", wantLen: 40},
 		// Width too small: trailing dashes are omitted, label still present.
 		{label: "LOGS", width: 5, wantContains: "LOGS", wantLen: 7}, // "── LOGS" = 7 runes

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -824,6 +825,141 @@ func TestTermWidth(t *testing.T) {
 	}
 }
 
+func TestFormatHostnameWidthOneReturnsEllipsis(t *testing.T) {
+	got := formatHostname("router-very-long-name", 1)
+	if got != "…" {
+		t.Fatalf("formatHostname(width=1) = %q, want %q", got, "…")
+	}
+}
+
+func TestLogWriterReturnsNilWhenNotLiveMode(t *testing.T) {
+	var buf bytes.Buffer
+	d := newTestDisplay(&buf, []string{"router1"})
+
+	w := d.LogWriter()
+	if w != nil {
+		t.Fatalf("LogWriter() = %#v, want nil when live mode is disabled", w)
+	}
+	if d.logWriter != nil {
+		t.Fatal("d.logWriter should remain nil when live mode is disabled")
+	}
+}
+
+func TestStopConcurrentSkipsEmptyPendingLines(t *testing.T) {
+	var buf bytes.Buffer
+	d := New(&buf, []string{"host1", "host2", "host3"}, InitOptions{Debug: false, PreferLiveMode: false, Concurrent: true})
+
+	d.pendingLines[0] = "✅ host1 done"
+	d.pendingLines[1] = ""
+	d.pendingLines[2] = "❌ host3 failed"
+
+	d.Stop()
+
+	got := strings.TrimSpace(buf.String())
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 output lines, got %d: %q", len(lines), got)
+	}
+	if lines[0] != "✅ host1 done" {
+		t.Fatalf("first line = %q, want %q", lines[0], "✅ host1 done")
+	}
+	if lines[1] != "❌ host3 failed" {
+		t.Fatalf("second line = %q, want %q", lines[1], "❌ host3 failed")
+	}
+}
+
+func TestRenderUnlockedInProgressNoSummaryNoCurrent(t *testing.T) {
+	h := &HostLine{
+		hostname:      "router1",
+		hostnameWidth: 10,
+		overallEmoji:  "⏳",
+		done:          false,
+	}
+
+	got := h.renderUnlocked()
+	if got != "⏳ router1   " {
+		t.Fatalf("renderUnlocked() = %q, want %q", got, "⏳ router1   ")
+	}
+}
+
+func TestRenderUnlockedInProgressSummaryOnly(t *testing.T) {
+	h := &HostLine{
+		hostname:      "router1",
+		hostnameWidth: 10,
+		overallEmoji:  "⏳",
+		history:       []completedStep{{emoji: "✅"}},
+		done:          false,
+	}
+
+	got := h.renderUnlocked()
+	if got != "⏳ router1    ✅" {
+		t.Fatalf("renderUnlocked() = %q, want %q", got, "⏳ router1    ✅")
+	}
+}
+
+func TestInitLiveModeFallbackOnStartError(t *testing.T) {
+	resetSingleton(t)
+
+	var buf bytes.Buffer
+	d := newLiveModeDisplay(&buf, []string{"router1", "router2"})
+	d.concurrent = true
+	d.pendingLines = nil
+
+	originalStart := startLiveTerm
+	startLiveTerm = func() error {
+		return errors.New("start failed")
+	}
+	t.Cleanup(func() {
+		startLiveTerm = originalStart
+	})
+
+	d.initLiveMode()
+
+	if d.liveMode {
+		t.Fatal("initLiveMode() should disable live mode when start fails")
+	}
+	if d.pendingLines == nil || len(d.pendingLines) != 2 {
+		t.Fatalf("expected pendingLines buffer of size 2 after fallback, got %#v", d.pendingLines)
+	}
+	for i, l := range d.lines {
+		if l.liveMode {
+			t.Fatalf("line %d should have liveMode=false after fallback", i)
+		}
+		if l.pending == nil {
+			t.Fatalf("line %d should be wired to pendingLines after fallback", i)
+		}
+	}
+
+	singletonMu.Lock()
+	current := activeLiveDisp
+	singletonMu.Unlock()
+	if current != nil {
+		t.Fatal("activeLiveDisp should be released on start failure")
+	}
+}
+
+func TestFinishSequentialWriteErrorStillUpdatesState(t *testing.T) {
+	h := &HostLine{
+		hostname:      "router1",
+		hostnameWidth: 10,
+		overallEmoji:  "⏳",
+		out:           failWriter{},
+		liveMode:      false,
+	}
+
+	h.Finish("❌", "write failed")
+
+	if !h.done {
+		t.Fatal("Finish() should set done=true even when write fails")
+	}
+	if h.overallEmoji != "❌" {
+		t.Fatalf("overallEmoji = %q, want %q", h.overallEmoji, "❌")
+	}
+	if h.finalMessage != "write failed" {
+		t.Fatalf("finalMessage = %q, want %q", h.finalMessage, "write failed")
+	}
+}
+
 // lockedWriter is a helper that serialises writes to an underlying writer using an external mutex.
 type lockedWriter struct {
 	mu *sync.Mutex
@@ -834,4 +970,10 @@ func (lw *lockedWriter) Write(p []byte) (int, error) {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 	return lw.w.Write(p)
+}
+
+type failWriter struct{}
+
+func (failWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
 }

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -832,6 +832,46 @@ func TestFormatHostnameWidthOneReturnsEllipsis(t *testing.T) {
 	}
 }
 
+func TestInitLiveLogWriterInitializesInLiveMode(t *testing.T) {
+	d := &LiveDisplay{liveMode: true, outFd: -1}
+
+	d.initLiveLogWriter()
+
+	if d.logWriter == nil {
+		t.Fatal("initLiveLogWriter() should initialize logWriter when live mode is enabled")
+	}
+	if d.logWriter.outFd != -1 {
+		t.Fatalf("logWriter.outFd = %d, want -1", d.logWriter.outFd)
+	}
+	if got := d.LogWriter(); got != d.logWriter {
+		t.Fatal("LogWriter() should return the eagerly initialized logWriter instance")
+	}
+}
+
+func TestInitLiveLogWriterNoOpWhenNotLiveMode(t *testing.T) {
+	d := &LiveDisplay{liveMode: false, outFd: -1}
+
+	d.initLiveLogWriter()
+
+	if d.logWriter != nil {
+		t.Fatal("initLiveLogWriter() should not initialize logWriter when live mode is disabled")
+	}
+}
+
+func TestLogWriterReturnsPreinitializedWriterInLiveMode(t *testing.T) {
+	want := &logWriter{base: io.Discard, outFd: -1}
+	d := &LiveDisplay{liveMode: true, logWriter: want}
+
+	got := d.LogWriter()
+
+	if got != want {
+		t.Fatalf("LogWriter() = %#v, want %#v", got, want)
+	}
+	if d.logWriter != want {
+		t.Fatal("LogWriter() should not replace the existing logWriter instance")
+	}
+}
+
 func TestLogWriterReturnsNilWhenNotLiveMode(t *testing.T) {
 	var buf bytes.Buffer
 	d := newTestDisplay(&buf, []string{"router1"})

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -2,7 +2,9 @@ package display
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -637,7 +639,7 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 	}
 }
 
-// TestRenderLinesDelimiterAlwaysPresent verifies the HOSTS STATUS delimiter is always
+// TestRenderLinesDelimiterAlwaysPresent verifies the HOST STATUS delimiter is always
 // the first output line, regardless of whether any logs have been written.
 func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
@@ -706,7 +708,8 @@ func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
 // and that the LOGS header is emitted exactly once before the first log line.
 func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 	var buf bytes.Buffer
-	w := &logWriterWithSeparator{base: &buf}
+	// outFd: -1 → termWidth returns 80 (no TTY fallback)
+	w := &logWriterWithSeparator{base: &buf, outFd: -1}
 
 	if w.HasWritten() {
 		t.Errorf("expected HasWritten=false initially, got true")
@@ -720,8 +723,9 @@ func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 		t.Errorf("expected HasWritten=true after Write(), got false")
 	}
 
-	// The LOGS header must appear before the log content.
-	want := logsHeader + "test log"
+	// The LOGS header must appear before the log content at the fallback width.
+	wantHeader := separatorLine("LOGS", 80) + "\n"
+	want := wantHeader + "test log"
 	if buf.String() != want {
 		t.Errorf("expected buffer %q, got: %q", want, buf.String())
 	}
@@ -740,7 +744,8 @@ func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
 	var buf bytes.Buffer
 	var bufMu sync.Mutex
-	w := &logWriterWithSeparator{base: &lockedWriter{mu: &bufMu, w: &buf}}
+	// outFd: -1 → termWidth returns 80 (no TTY fallback)
+	w := &logWriterWithSeparator{base: &lockedWriter{mu: &bufMu, w: &buf}, outFd: -1}
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
@@ -761,11 +766,61 @@ func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
 		t.Errorf("expected data in buffer after concurrent writes")
 	}
 	// Header must appear exactly once at the very beginning.
-	if !strings.HasPrefix(got, logsHeader) {
+	wantHeader := separatorLine("LOGS", 80) + "\n"
+	if !strings.HasPrefix(got, wantHeader) {
 		t.Errorf("expected buffer to start with LOGS header, got: %q", got[:min(len(got), 60)])
 	}
-	if strings.Count(got, logsHeader) != 1 {
-		t.Errorf("LOGS header should appear exactly once, got %d occurrences", strings.Count(got, logsHeader))
+	if strings.Count(got, wantHeader) != 1 {
+		t.Errorf("LOGS header should appear exactly once, got %d occurrences", strings.Count(got, wantHeader))
+	}
+}
+
+// TestSeparatorLine verifies separatorLine builds correctly-sized strings.
+func TestSeparatorLine(t *testing.T) {
+	tests := []struct {
+		label        string
+		width        int
+		wantContains string
+		wantLen      int // expected rune length of output
+	}{
+		{label: "LOGS", width: 80, wantContains: "LOGS", wantLen: 80},
+		{label: "HOST STATUS", width: 80, wantContains: "HOST STATUS", wantLen: 80},
+		{label: "LOGS", width: 40, wantContains: "LOGS", wantLen: 40},
+		// Width too small: trailing dashes are omitted, label still present.
+		{label: "LOGS", width: 5, wantContains: "LOGS", wantLen: 7}, // "── LOGS" = 7 runes
+		{label: "LOGS", width: 0, wantContains: "LOGS", wantLen: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/w=%d", tt.label, tt.width), func(t *testing.T) {
+			got := separatorLine(tt.label, tt.width)
+			if !strings.Contains(got, tt.label) {
+				t.Errorf("separatorLine(%q, %d) = %q: label missing", tt.label, tt.width, got)
+			}
+			if gotLen := len([]rune(got)); gotLen != tt.wantLen {
+				t.Errorf("separatorLine(%q, %d) rune length = %d, want %d: %q",
+					tt.label, tt.width, gotLen, tt.wantLen, got)
+			}
+		})
+	}
+}
+
+// TestTermWidth verifies termWidth returns 80 for non-TTY file descriptors.
+func TestTermWidth(t *testing.T) {
+	// fd=-1 is the explicit no-TTY sentinel.
+	if got := termWidth(-1); got != 80 {
+		t.Errorf("termWidth(-1) = %d, want 80", got)
+	}
+
+	// A pipe read-end is never a TTY; GetSize will fail → fallback to 80.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	if got := termWidth(int(r.Fd())); got != 80 {
+		t.Errorf("termWidth(pipe fd) = %d, want 80 (pipe is not a TTY)", got)
 	}
 }
 

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -662,7 +662,7 @@ func TestRenderLinesBlankLineWhenLogsWritten(t *testing.T) {
 	d.Line(0).UpdateStep("⏳", "working")
 
 	// Simulate log writes by wiring a logWriter that has already written.
-	d.logWriter = &logWriterWithSeparator{base: io.Discard, hasWritten: true}
+	d.logWriter = &logWriter{base: io.Discard, hasWritten: true}
 
 	snapshot := d.renderLines()
 
@@ -710,7 +710,7 @@ func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
 func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 	var buf bytes.Buffer
 	// outFd: -1 → termWidth returns 80 (no TTY fallback)
-	w := &logWriterWithSeparator{base: &buf, outFd: -1}
+	w := &logWriter{base: &buf, outFd: -1}
 
 	if w.HasWritten() {
 		t.Errorf("expected HasWritten=false initially, got true")
@@ -746,7 +746,7 @@ func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
 	var buf bytes.Buffer
 	var bufMu sync.Mutex
 	// outFd: -1 → termWidth returns 80 (no TTY fallback)
-	w := &logWriterWithSeparator{base: &lockedWriter{mu: &bufMu, w: &buf}, outFd: -1}
+	w := &logWriter{base: &lockedWriter{mu: &bufMu, w: &buf}, outFd: -1}
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -776,6 +776,65 @@ func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
 	}
 }
 
+func TestLogWriterHeaderWriteFailureReturnsError(t *testing.T) {
+	w := &logWriter{base: failWriter{}, outFd: -1}
+
+	n, err := w.Write([]byte("test log"))
+
+	if err == nil {
+		t.Fatal("Write() should return an error when header write fails")
+	}
+	if n != 0 {
+		t.Fatalf("Write() bytes written = %d, want 0 on header failure", n)
+	}
+	if w.HasWritten() {
+		t.Fatal("HasWritten() should remain false when header write fails")
+	}
+}
+
+func TestLogWriterHeaderWriteFailureIsRetryable(t *testing.T) {
+	base := &failOnceWriter{}
+	w := &logWriter{base: base, outFd: -1}
+
+	if _, err := w.Write([]byte("first log")); err == nil {
+		t.Fatal("first Write() should fail when header write fails")
+	}
+	if w.HasWritten() {
+		t.Fatal("HasWritten() should remain false after transient header failure")
+	}
+
+	if n, err := w.Write([]byte("second log")); err != nil {
+		t.Fatalf("second Write() error = %v, want success", err)
+	} else if n != len("second log") {
+		t.Fatalf("second Write() bytes written = %d, want %d", n, len("second log"))
+	}
+	if !w.HasWritten() {
+		t.Fatal("HasWritten() should be true after successful retry")
+	}
+
+	got := base.buf.String()
+	want := "── LOGS\nsecond log"
+	if got != want {
+		t.Fatalf("buffer = %q, want %q", got, want)
+	}
+}
+
+func TestLogWriterHeaderShortWriteReturnsError(t *testing.T) {
+	w := &logWriter{base: shortWriteWriter{}, outFd: -1}
+
+	n, err := w.Write([]byte("test log"))
+
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Write() error = %v, want io.ErrShortWrite", err)
+	}
+	if n != 0 {
+		t.Fatalf("Write() bytes written = %d, want 0 on short header write", n)
+	}
+	if w.HasWritten() {
+		t.Fatal("HasWritten() should remain false when header write is short")
+	}
+}
+
 // TestSeparatorLine verifies separatorLine builds correctly-sized strings.
 func TestSeparatorLine(t *testing.T) {
 	tests := []struct {
@@ -1010,6 +1069,28 @@ func (lw *lockedWriter) Write(p []byte) (int, error) {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 	return lw.w.Write(p)
+}
+
+type failOnceWriter struct {
+	buf    bytes.Buffer
+	failed bool
+}
+
+func (w *failOnceWriter) Write(p []byte) (int, error) {
+	if !w.failed {
+		w.failed = true
+		return 0, errors.New("write failed once")
+	}
+	return w.buf.Write(p)
+}
+
+type shortWriteWriter struct{}
+
+func (shortWriteWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
 }
 
 type failWriter struct{}

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -639,7 +639,7 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 	}
 }
 
-// TestRenderLinesDelimiterAlwaysPresent verifies the HOST STATUS delimiter is always
+// TestRenderLinesDelimiterAlwaysPresent verifies the HOSTS STATUS delimiter is always
 // the first output line, regardless of whether any logs have been written.
 func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -723,8 +723,8 @@ func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 		t.Errorf("expected HasWritten=true after Write(), got false")
 	}
 
-	// The LOGS header must appear before the log content at the fallback width.
-	wantHeader := separatorLine("LOGS", 80) + "\n"
+	// The LOGS header must appear before the log content.
+	wantHeader := "── LOGS\n"
 	want := wantHeader + "test log"
 	if buf.String() != want {
 		t.Errorf("expected buffer %q, got: %q", want, buf.String())
@@ -766,7 +766,7 @@ func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
 		t.Errorf("expected data in buffer after concurrent writes")
 	}
 	// Header must appear exactly once at the very beginning.
-	wantHeader := separatorLine("LOGS", 80) + "\n"
+	wantHeader := "── LOGS\n"
 	if !strings.HasPrefix(got, wantHeader) {
 		t.Errorf("expected buffer to start with LOGS header, got: %q", got[:min(len(got), 60)])
 	}

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -641,7 +641,8 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 }
 
 // TestRenderLinesDelimiterAlwaysPresent verifies the HOSTS STATUS delimiter is always
-// the first output line, regardless of whether any logs have been written.
+// present in the output: it is the first line when no logs have been written, and
+// is preceded by a blank separator line when logs have been written.
 func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
 

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -560,39 +561,47 @@ func TestConcurrentFailureRenderAtomicity(t *testing.T) {
 	wg.Wait()
 
 	// After all goroutines complete, verify renderLines() produces a consistent snapshot.
-	// The snapshot should contain ONLY final states (✅, ❓), never intermediate states (⏳ Connecting).
+	// The snapshot contains: optional blank line, delimiter, then one line per host.
+	// We only inspect host lines (starting at offset 1 for delimiter, no blank line since no logs).
 	snapshot := d.renderLines()
 
-	for i, line := range snapshot {
-		host := hosts[i]
+	// Without logs, snapshot = [delimiter, host0, host1, ...]
+	offset := 1 // skip delimiter
+	if len(snapshot) != len(hosts)+offset {
+		t.Fatalf("expected %d snapshot lines (delimiter + %d hosts), got %d: %v",
+			len(hosts)+offset, len(hosts), len(snapshot), snapshot)
+	}
+
+	for i, host := range hosts {
+		line := snapshot[i+offset]
 		t.Logf("Final snapshot for %s: %s", host, line)
 
 		// Every line should start with a final emoji, not intermediate
 		if !strings.HasPrefix(line, "✅") && !strings.HasPrefix(line, "❓") {
 			t.Errorf("snapshot[%d] for %q = %q, expected final emoji (✅ or ❓), not intermediate state",
-				i, host, line)
+				i+offset, host, line)
 		}
 
 		// No intermediate "Connecting" text should appear
 		if strings.Contains(line, "Connecting to router…") {
 			t.Errorf("snapshot[%d] for %q contains intermediate step 'Connecting to router…', should be final only: %q",
-				i, host, line)
+				i+offset, host, line)
 		}
 
 		// Verify expected final states
 		if failingHosts[host] {
 			if !strings.HasPrefix(line, "❓") {
-				t.Errorf("snapshot[%d] for %q = %q, expected ❓ (unknown/failed status)", i, host, line)
+				t.Errorf("snapshot[%d] for %q = %q, expected ❓ (unknown/failed status)", i+offset, host, line)
 			}
 			if !strings.Contains(line, "failed to dial") {
-				t.Errorf("snapshot[%d] for %q = %q, expected failure message", i, host, line)
+				t.Errorf("snapshot[%d] for %q = %q, expected failure message", i+offset, host, line)
 			}
 		} else {
 			if !strings.HasPrefix(line, "✅") {
-				t.Errorf("snapshot[%d] for %q = %q, expected ✅ (success)", i, host, line)
+				t.Errorf("snapshot[%d] for %q = %q, expected ✅ (success)", i+offset, host, line)
 			}
 			if !strings.Contains(line, "is up-to-date") {
-				t.Errorf("snapshot[%d] for %q = %q, expected success message", i, host, line)
+				t.Errorf("snapshot[%d] for %q = %q, expected success message", i+offset, host, line)
 			}
 		}
 	}
@@ -611,15 +620,163 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 	d.Line(1).CompleteStep("✅")
 	d.Line(2).UpdateStep("⏳", "step2")
 
+	// Without logs: delimiter + 3 hosts = 4 lines.
 	// Call renderLines multiple times: should always see the same state
 	// (deadlock would manifest as goroutine hanging, race detector would catch non-atomic reads)
 	for i := 0; i < 100; i++ {
 		snapshot := d.renderLines()
-		if len(snapshot) != 3 {
-			t.Errorf("iteration %d: renderLines returned %d lines, want 3", i, len(snapshot))
+		if len(snapshot) != 4 {
+			t.Errorf("iteration %d: renderLines returned %d lines, want 4 (delimiter + 3 hosts)", i, len(snapshot))
 		}
-		if !strings.Contains(snapshot[0], "step1") {
-			t.Errorf("iteration %d: snapshot[0] lost 'step1', got %q", i, snapshot[0])
+		if !strings.Contains(snapshot[0], "HOST STATUS") {
+			t.Errorf("iteration %d: snapshot[0] should be delimiter, got %q", i, snapshot[0])
+		}
+		if !strings.Contains(snapshot[1], "step1") {
+			t.Errorf("iteration %d: snapshot[1] lost 'step1', got %q", i, snapshot[1])
 		}
 	}
+}
+
+// TestRenderLinesDelimiterAlwaysPresent verifies the HOST STATUS delimiter is always
+// the first output line, regardless of whether any logs have been written.
+func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
+	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
+
+	snapshot := d.renderLines()
+
+	if len(snapshot) < 1 {
+		t.Fatalf("expected at least 1 line, got 0")
+	}
+	if !strings.Contains(snapshot[0], "HOST STATUS") {
+		t.Errorf("delimiter should be first when no logs written, got: %q", snapshot[0])
+	}
+}
+
+// TestRenderLinesBlankLineWhenLogsWritten verifies that a blank separator line is
+// prepended before the HOST STATUS delimiter when logs have been written.
+func TestRenderLinesBlankLineWhenLogsWritten(t *testing.T) {
+	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
+	d.Line(0).UpdateStep("⏳", "working")
+
+	// Simulate log writes by wiring a logWriter that has already written.
+	d.logWriter = &logWriterWithSeparator{base: io.Discard, hasWritten: true}
+
+	snapshot := d.renderLines()
+
+	// blank + delimiter + 2 host lines = 4 lines
+	if len(snapshot) != 4 {
+		t.Fatalf("with logs: expected 4 lines, got %d: %v", len(snapshot), snapshot)
+	}
+	if snapshot[0] != "" {
+		t.Errorf("with logs: first line should be blank, got: %q", snapshot[0])
+	}
+	if !strings.Contains(snapshot[1], "HOST STATUS") {
+		t.Errorf("with logs: second line should be delimiter, got: %q", snapshot[1])
+	}
+	if !strings.Contains(snapshot[2], "host1") {
+		t.Errorf("with logs: host1 should be at index 2, got: %q", snapshot[2])
+	}
+}
+
+// TestRenderLinesNoBlankLineWithoutLogs verifies that no blank line is added
+// before the HOST STATUS delimiter when no logs have been written.
+func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
+	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
+	d.Line(0).UpdateStep("⏳", "working")
+
+	// No logWriter set — simulates a run with no log output.
+	snapshot := d.renderLines()
+
+	// delimiter + 2 host lines = 3 lines
+	if len(snapshot) != 3 {
+		t.Fatalf("without logs: expected 3 lines, got %d: %v", len(snapshot), snapshot)
+	}
+	if snapshot[0] == "" {
+		t.Errorf("without logs: first line should NOT be blank")
+	}
+	if !strings.Contains(snapshot[0], "HOST STATUS") {
+		t.Errorf("without logs: first line should be delimiter, got: %q", snapshot[0])
+	}
+	if !strings.Contains(snapshot[1], "host1") {
+		t.Errorf("without logs: host1 should be at index 1, got: %q", snapshot[1])
+	}
+}
+
+// TestLogWriterWithSeparatorTracksWrites verifies HasWritten reflects write state
+// and that the LOGS header is emitted exactly once before the first log line.
+func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := &logWriterWithSeparator{base: &buf}
+
+	if w.HasWritten() {
+		t.Errorf("expected HasWritten=false initially, got true")
+	}
+
+	if _, err := w.Write([]byte("test log")); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	if !w.HasWritten() {
+		t.Errorf("expected HasWritten=true after Write(), got false")
+	}
+
+	// The LOGS header must appear before the log content.
+	want := logsHeader + "test log"
+	if buf.String() != want {
+		t.Errorf("expected buffer %q, got: %q", want, buf.String())
+	}
+
+	// A second write must not repeat the header.
+	if _, err := w.Write([]byte(" second")); err != nil {
+		t.Fatalf("second Write() error: %v", err)
+	}
+	if buf.String() != want+" second" {
+		t.Errorf("header should appear only once, got: %q", buf.String())
+	}
+}
+
+// TestLogWriterWithSeparatorThreadSafe verifies concurrent writes are tracked safely
+// and that the LOGS header appears exactly once regardless of concurrency.
+func TestLogWriterWithSeparatorThreadSafe(t *testing.T) {
+	var buf bytes.Buffer
+	var bufMu sync.Mutex
+	w := &logWriterWithSeparator{base: &lockedWriter{mu: &bufMu, w: &buf}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			w.Write([]byte("log\n")) //nolint:errcheck
+		}(i)
+	}
+	wg.Wait()
+
+	if !w.HasWritten() {
+		t.Errorf("expected HasWritten=true after concurrent writes")
+	}
+
+	got := buf.String()
+	if got == "" {
+		t.Errorf("expected data in buffer after concurrent writes")
+	}
+	// Header must appear exactly once at the very beginning.
+	if !strings.HasPrefix(got, logsHeader) {
+		t.Errorf("expected buffer to start with LOGS header, got: %q", got[:min(len(got), 60)])
+	}
+	if strings.Count(got, logsHeader) != 1 {
+		t.Errorf("LOGS header should appear exactly once, got %d occurrences", strings.Count(got, logsHeader))
+	}
+}
+
+// lockedWriter is a helper that serialises writes to an underlying writer using an external mutex.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (lw *lockedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
 }

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -817,8 +817,8 @@ func TestTermWidth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Pipe() error: %v", err)
 	}
-	defer r.Close()
-	defer w.Close()
+	defer r.Close() //nolint:errcheck
+	defer w.Close() //nolint:errcheck
 	if got := termWidth(int(r.Fd())); got != 80 {
 		t.Errorf("termWidth(pipe fd) = %d, want 80 (pipe is not a TTY)", got)
 	}

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -710,8 +710,8 @@ func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
 // and that the LOGS header is emitted exactly once before the first log line.
 func TestLogWriterWithSeparatorTracksWrites(t *testing.T) {
 	var buf bytes.Buffer
-	// outFd: -1 → termWidth returns 80 (no TTY fallback)
-	w := &logWriter{base: &buf, outFd: -1}
+	// Only the output buffer matters for this behavior under test.
+	w := &logWriter{base: &buf}
 
 	if w.HasWritten() {
 		t.Errorf("expected HasWritten=false initially, got true")

--- a/common/display/display_test.go
+++ b/common/display/display_test.go
@@ -628,7 +628,7 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 		if len(snapshot) != 4 {
 			t.Errorf("iteration %d: renderLines returned %d lines, want 4 (delimiter + 3 hosts)", i, len(snapshot))
 		}
-		if !strings.Contains(snapshot[0], "HOST STATUS") {
+		if !strings.Contains(snapshot[0], "HOSTS STATUS") {
 			t.Errorf("iteration %d: snapshot[0] should be delimiter, got %q", i, snapshot[0])
 		}
 		if !strings.Contains(snapshot[1], "step1") {
@@ -637,7 +637,7 @@ func TestRenderLinesLocksAllHosts(t *testing.T) {
 	}
 }
 
-// TestRenderLinesDelimiterAlwaysPresent verifies the HOST STATUS delimiter is always
+// TestRenderLinesDelimiterAlwaysPresent verifies the HOSTS STATUS delimiter is always
 // the first output line, regardless of whether any logs have been written.
 func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
@@ -647,13 +647,13 @@ func TestRenderLinesDelimiterAlwaysPresent(t *testing.T) {
 	if len(snapshot) < 1 {
 		t.Fatalf("expected at least 1 line, got 0")
 	}
-	if !strings.Contains(snapshot[0], "HOST STATUS") {
+	if !strings.Contains(snapshot[0], "HOSTS STATUS") {
 		t.Errorf("delimiter should be first when no logs written, got: %q", snapshot[0])
 	}
 }
 
 // TestRenderLinesBlankLineWhenLogsWritten verifies that a blank separator line is
-// prepended before the HOST STATUS delimiter when logs have been written.
+// prepended before the HOSTS STATUS delimiter when logs have been written.
 func TestRenderLinesBlankLineWhenLogsWritten(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
 	d.Line(0).UpdateStep("⏳", "working")
@@ -670,7 +670,7 @@ func TestRenderLinesBlankLineWhenLogsWritten(t *testing.T) {
 	if snapshot[0] != "" {
 		t.Errorf("with logs: first line should be blank, got: %q", snapshot[0])
 	}
-	if !strings.Contains(snapshot[1], "HOST STATUS") {
+	if !strings.Contains(snapshot[1], "HOSTS STATUS") {
 		t.Errorf("with logs: second line should be delimiter, got: %q", snapshot[1])
 	}
 	if !strings.Contains(snapshot[2], "host1") {
@@ -679,7 +679,7 @@ func TestRenderLinesBlankLineWhenLogsWritten(t *testing.T) {
 }
 
 // TestRenderLinesNoBlankLineWithoutLogs verifies that no blank line is added
-// before the HOST STATUS delimiter when no logs have been written.
+// before the HOSTS STATUS delimiter when no logs have been written.
 func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
 	d := newLiveModeDisplay(new(bytes.Buffer), []string{"host1", "host2"})
 	d.Line(0).UpdateStep("⏳", "working")
@@ -694,7 +694,7 @@ func TestRenderLinesNoBlankLineWithoutLogs(t *testing.T) {
 	if snapshot[0] == "" {
 		t.Errorf("without logs: first line should NOT be blank")
 	}
-	if !strings.Contains(snapshot[0], "HOST STATUS") {
+	if !strings.Contains(snapshot[0], "HOSTS STATUS") {
 		t.Errorf("without logs: first line should be delimiter, got: %q", snapshot[0])
 	}
 	if !strings.Contains(snapshot[1], "host1") {


### PR DESCRIPTION
Enhance the console output by improving the separation between logs and host status, ensuring that "HOSTS STATUS" delimiter line resize dynamically with the terminal.