### PR TITLE
feat(cmd/discover) Improve discover subcommand topology display

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ mikrotik-fleet-autopilot discover [options]
 ```
 
 **Options:**
-- `--connected-to <device-identity>` - Add a synthetic `mfa` node to the topology graph and show it as connected to the specified discovered device identity
+- `--connected-to <device-identity>` - Add a synthetic `mfa` node to the topology graph and show it as connected to the specified topology node identity. This can be a discovered LLDP device identity or a configured source host already present in the graph.
 
 **Examples:**
 ```bash
 # Discover topology from configured routers
 mikrotik-fleet-autopilot discover
 
-# Show the local mfa computer as connected to a discovered device
+# Show the local mfa computer as connected to a topology node identity
 mikrotik-fleet-autopilot discover --connected-to router1.home
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ mikrotik-fleet-autopilot --host router1.local,192.168.1.1 --ssh-user admin --ssh
 
 ### Available Commands
 
+#### discover
+Discover LLDP topology across the configured routers.
+
+```bash
+mikrotik-fleet-autopilot discover [options]
+```
+
+**Options:**
+- `--connected-to <device-identity>` - Add a synthetic `mfa` node to the topology graph and show it as connected to the specified discovered device identity
+
+**Examples:**
+```bash
+# Discover topology from configured routers
+mikrotik-fleet-autopilot discover
+
+# Show the local mfa computer as connected to a discovered device
+mikrotik-fleet-autopilot discover --connected-to router1.home
+```
+
 #### export
 Export MikroTik router configuration to `.rsc` files.
 

--- a/cmd/discover/discover.go
+++ b/cmd/discover/discover.go
@@ -17,13 +17,21 @@ var Command = []*cli.Command{
 	{
 		Name:  "discover",
 		Usage: "Discover LLDP network topology across all routers",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "connected-to",
+				Usage: "Show the local mfa computer as connected to a discovered device identity",
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runDiscoverForHosts(ctx, os.Stdout)
+			return runDiscoverForHosts(ctx, os.Stdout, cmd.String("connected-to"))
 		},
 	},
 }
 
-func runDiscoverForHosts(ctx context.Context, out io.Writer) error {
+var createSSHConnection = ssh.CreateConnection
+
+func runDiscoverForHosts(ctx context.Context, out io.Writer, connectedTo string) error {
 	// Get global config
 	cfg, err := core.GetConfig(ctx)
 	if err != nil {
@@ -56,7 +64,7 @@ func runDiscoverForHosts(ctx context.Context, out io.Writer) error {
 	)
 
 	// Render output
-	return outputTopology(out, topology)
+	return outputTopology(out, topology, connectedTo)
 }
 
 // topology holds discovery results indexed by source host
@@ -78,7 +86,7 @@ func discoverTopology(ctx context.Context, hosts []string) (*topology, error) {
 		slog.Info("connecting to host", "host", host)
 
 		// Connect
-		conn, err := ssh.CreateConnection(ctx, host)
+		conn, err := createSSHConnection(ctx, host)
 		if err != nil {
 			slog.Warn("connection failed", "host", host, "error", err)
 			topo.errors[host] = fmt.Errorf("connection failed: %w", err)

--- a/cmd/discover/discover.go
+++ b/cmd/discover/discover.go
@@ -20,7 +20,7 @@ var Command = []*cli.Command{
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "connected-to",
-				Usage: "Show the local mfa computer as connected to a discovered device identity",
+				Usage: "Show the local mfa computer as connected to a device identity or source host already present in the topology graph",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/discover/discover.go
+++ b/cmd/discover/discover.go
@@ -29,9 +29,23 @@ var Command = []*cli.Command{
 	},
 }
 
-var createSSHConnection = ssh.CreateConnection
+type discoverDeps struct {
+	createSSHConnection any
+}
+
+func defaultDiscoverDeps() discoverDeps {
+	return discoverDeps{
+		createSSHConnection: ssh.CreateConnection,
+	}
+}
 
 func runDiscoverForHosts(ctx context.Context, out io.Writer, connectedTo string) error {
+	return runDiscoverForHostsWithDeps(ctx, out, connectedTo, defaultDiscoverDeps())
+}
+
+func runDiscoverForHostsWithDeps(ctx context.Context, out io.Writer, connectedTo string, deps discoverDeps) error {
+	_ = deps
+
 	// Get global config
 	cfg, err := core.GetConfig(ctx)
 	if err != nil {

--- a/cmd/discover/discover.go
+++ b/cmd/discover/discover.go
@@ -29,23 +29,9 @@ var Command = []*cli.Command{
 	},
 }
 
-type discoverDeps struct {
-	createSSHConnection any
-}
-
-func defaultDiscoverDeps() discoverDeps {
-	return discoverDeps{
-		createSSHConnection: ssh.CreateConnection,
-	}
-}
+var createSSHConnection = ssh.CreateConnection
 
 func runDiscoverForHosts(ctx context.Context, out io.Writer, connectedTo string) error {
-	return runDiscoverForHostsWithDeps(ctx, out, connectedTo, defaultDiscoverDeps())
-}
-
-func runDiscoverForHostsWithDeps(ctx context.Context, out io.Writer, connectedTo string, deps discoverDeps) error {
-	_ = deps
-
 	// Get global config
 	cfg, err := core.GetConfig(ctx)
 	if err != nil {

--- a/cmd/discover/discover_test.go
+++ b/cmd/discover/discover_test.go
@@ -1,10 +1,33 @@
 package discover
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"reflect"
+	"strings"
 	"testing"
 
+	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/lldp"
+	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 )
+
+type stubRunner struct {
+	runOutput string
+}
+
+func (s *stubRunner) Run(cmd string) (string, error) {
+	return s.runOutput, nil
+}
+
+func (s *stubRunner) Close() error {
+	return nil
+}
+
+func (s *stubRunner) IsAlreadyClosedError(err error) bool {
+	return false
+}
 
 func TestBuildTopologyGraph_Basic(t *testing.T) {
 	results := map[string]*lldp.ParseResult{
@@ -23,7 +46,10 @@ func TestBuildTopologyGraph_Basic(t *testing.T) {
 		},
 	}
 
-	graph := buildTopologyGraph(results, []string{"device1", "device2"})
+	graph, err := buildTopologyGraph(results, []string{"device1", "device2"}, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
 	if len(graph.nodes) != 2 {
 		t.Fatalf("expected 2 devices in graph, got %d", len(graph.nodes))
 	}
@@ -55,7 +81,10 @@ func TestBuildTopologyGraph_RedundantLinksMultiplicity(t *testing.T) {
 		},
 	}
 
-	graph := buildTopologyGraph(results, []string{"source"})
+	graph, err := buildTopologyGraph(results, []string{"source"}, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
 	edges := graph.outgoing["source"]["peer"]
 	if len(edges) != 2 {
 		t.Fatalf("expected 2 parallel links source->peer, got %d", len(edges))
@@ -74,15 +103,289 @@ func TestSelectRoots_PrefersHigherDegree(t *testing.T) {
 		"c": {Neighbors: []*lldp.Neighbor{}},
 	}
 
-	graph := buildTopologyGraph(results, []string{"a", "b", "c"})
+	graph, err := buildTopologyGraph(results, []string{"a", "b", "c"}, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
 	components := connectedComponents(graph)
-	roots := selectRoots(graph, components, []string{"a", "b", "c"})
+	roots := selectRoots(graph, components, []string{"a", "b", "c"}, "")
 	if len(roots) != 1 {
 		t.Fatalf("expected 1 component root, got %d", len(roots))
 	}
 	if roots[0] != "a" {
 		t.Errorf("expected root a (highest degree), got %s", roots[0])
 	}
+}
+
+func TestBuildTopologyGraph_ConnectedToAddsMFANode(t *testing.T) {
+	results := map[string]*lldp.ParseResult{
+		"router1": {
+			Neighbors: []*lldp.Neighbor{
+				{Identity: "router2"},
+			},
+		},
+		"router2": {Neighbors: []*lldp.Neighbor{}},
+	}
+
+	graph, err := buildTopologyGraph(results, []string{"router1", "router2"}, "router2")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
+
+	if _, ok := graph.nodes[mfaNodeName]; !ok {
+		t.Fatalf("expected synthetic %q node to exist", mfaNodeName)
+	}
+	if graph.nodes[mfaNodeName].isSource {
+		t.Fatalf("expected synthetic %q node to be non-source", mfaNodeName)
+	}
+	edges := graph.outgoing[mfaNodeName]["router2"]
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 synthetic edge from %s to router2, got %d", mfaNodeName, len(edges))
+	}
+
+	components := connectedComponents(graph)
+	roots := selectRoots(graph, components, []string{"router1", "router2"}, preferredRoot(graph))
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 component root, got %d", len(roots))
+	}
+	if roots[0] != mfaNodeName {
+		t.Fatalf("expected synthetic node %q to be selected as root, got %q", mfaNodeName, roots[0])
+	}
+}
+
+func TestBuildTopologyGraph_ConnectedToUnknownTargetFails(t *testing.T) {
+	results := map[string]*lldp.ParseResult{
+		"router1": {Neighbors: []*lldp.Neighbor{}},
+	}
+
+	_, err := buildTopologyGraph(results, []string{"router1"}, "router2")
+	if err == nil {
+		t.Fatal("expected error for unknown connected-to target, got nil")
+	}
+	if !strings.Contains(err.Error(), "router2") {
+		t.Fatalf("expected error to mention missing target, got %v", err)
+	}
+}
+
+func TestRunDiscoverForHosts_DoesNotConnectToSyntheticMFANode(t *testing.T) {
+	ctx := context.WithValue(context.Background(), core.ConfigKey, &core.Config{
+		Hosts: []string{"router1"},
+	})
+
+	var connectedHosts []string
+	originalFactory := createSSHConnection
+	createSSHConnection = func(ctx context.Context, host string) (ssh.RunnerInterface, error) {
+		connectedHosts = append(connectedHosts, host)
+		return &stubRunner{runOutput: ""}, nil
+	}
+	defer func() {
+		createSSHConnection = originalFactory
+	}()
+
+	if err := runDiscoverForHosts(ctx, io.Discard, "router1"); err != nil {
+		t.Fatalf("runDiscoverForHosts() unexpected error = %v", err)
+	}
+
+	if !reflect.DeepEqual(connectedHosts, []string{"router1"}) {
+		t.Fatalf("expected SSH connections only for configured hosts, got %v", connectedHosts)
+	}
+	for _, host := range connectedHosts {
+		if host == mfaNodeName {
+			t.Fatalf("synthetic node %q must never be used as an SSH target", mfaNodeName)
+		}
+	}
+}
+
+func TestOutputTopology_ConnectedToRendersMFAAsRoot(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2"},
+				},
+			},
+			"router2": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, "router2"); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "[mfa]") {
+		t.Fatalf("expected rendered topology to contain mfa root, got output:\n%s", out.String())
+	}
+	lines := strings.Split(out.String(), "\n")
+	rootLineFound := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "[") {
+			rootLineFound = true
+			if line != "[mfa]" {
+				t.Fatalf("expected first rendered root to be [mfa], got %q", line)
+			}
+			break
+		}
+	}
+	if !rootLineFound {
+		t.Fatalf("expected rendered topology to contain a root line, got output:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "via ? <-> ?") {
+		t.Fatalf("expected synthetic mfa edge to avoid empty via lines, got output:\n%s", out.String())
+	}
+}
+
+func TestOutputTopology_RendersViaLineForSingleLink(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2", LocalInterface: "ether1", RemoteInterface: "sfp1"},
+				},
+			},
+			"router2": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "via ether1 ↔ sfp1") {
+		t.Fatalf("expected output to contain via line for single link, got output:\n%s", out.String())
+	}
+}
+
+func TestOutputTopology_RendersViaLinesForParallelLinks(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2", LocalInterface: "ether1", RemoteInterface: "sfp1"},
+					{Identity: "router2", LocalInterface: "ether2", RemoteInterface: "sfp2"},
+				},
+			},
+			"router2": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "via ether1 ↔ sfp1") {
+		t.Fatalf("expected output to contain first via line for parallel links, got output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "via ether2 ↔ sfp2") {
+		t.Fatalf("expected output to contain second via line for parallel links, got output:\n%s", out.String())
+	}
+}
+
+func TestOutputTopology_RendersViaFallbackForMissingLocalInterface(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2", RemoteInterface: "sfp1"},
+				},
+			},
+			"router2": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "via ? ↔ sfp1") {
+		t.Fatalf("expected output to contain fallback via line for missing local interface, got output:\n%s", out.String())
+	}
+}
+
+func TestOutputTopology_ViaLineShowsVerticalBarWhenChildrenExist(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2", "router3", "router4"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2", LocalInterface: "ether1", RemoteInterface: "sfp1"},
+				},
+			},
+			"router2": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router3", LocalInterface: "ether2", RemoteInterface: "sfp2"},
+				},
+			},
+			"router3": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router4", LocalInterface: "ether3", RemoteInterface: "sfp3"},
+				},
+			},
+			"router4": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	output := out.String()
+	lines := strings.Split(output, "\n")
+	foundViaWithBar := false
+	for _, line := range lines {
+		if strings.Contains(line, "│  via") {
+			foundViaWithBar = true
+			break
+		}
+	}
+	if !foundViaWithBar {
+		t.Fatalf("expected via line with vertical bar (│) when child nodes exist, got output:\n%s", output)
+	}
+}
+
+func TestOutputTopology_ViaLineHasNoBarForLeafNode(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {
+				Neighbors: []*lldp.Neighbor{
+					{Identity: "router2", LocalInterface: "ether1", RemoteInterface: "sfp1"},
+				},
+			},
+			"router2": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	output := out.String()
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "via ether1 ↔ sfp1") {
+			if strings.HasPrefix(strings.TrimLeft(line, " "), "│") {
+				t.Fatalf("expected via line WITHOUT vertical bar (|) for leaf node, but found bar in: %q", line)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected to find via line in output, got output:\n%s", output)
 }
 
 func TestShortName(t *testing.T) {

--- a/cmd/discover/discover_test.go
+++ b/cmd/discover/discover_test.go
@@ -232,7 +232,7 @@ func TestOutputTopology_ConnectedToRendersMFAAsRoot(t *testing.T) {
 	if !rootLineFound {
 		t.Fatalf("expected rendered topology to contain a root line, got output:\n%s", out.String())
 	}
-	if strings.Contains(out.String(), "via ? <-> ?") {
+	if strings.Contains(out.String(), "via ? ↔ ?") {
 		t.Fatalf("expected synthetic mfa edge to avoid empty via lines, got output:\n%s", out.String())
 	}
 }

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -145,7 +145,7 @@ func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []str
 	}
 
 	if _, ok := graph.nodes[connectedTo]; !ok {
-		return nil, fmt.Errorf("connected-to target %q was not discovered; use a discovered device identity", connectedTo)
+		return nil, fmt.Errorf("connected-to target %q was not found in the topology; use a configured source host or a discovered device identity", connectedTo)
 	}
 
 	// mfa is a synthetic graph-only node representing the computer running the tool.

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -506,9 +506,7 @@ func renderChildren(out io.Writer, graph *topologyGraph, parent string, children
 			}
 			_, _ = fmt.Fprintf(out, "%s%s   %s  via %s ↔ %s\n", indent, vertBar, detailConnector, local, remote)
 		}
-		if vertBar != " " || detailConnector != " " {
-			_, _ = fmt.Fprintf(out, "%s%s   %s\n", indent, vertBar, detailConnector)
-		}
+		_, _ = fmt.Fprintf(out, "%s%s   %s\n", indent, vertBar, detailConnector)
 
 		nextIndent := indent + vertBar + "   "
 		renderChildren(out, graph, child, children, nextIndent)
@@ -581,7 +579,7 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int) {
 		totalLinks += len(edges)
 	}
 
-	_, _ = fmt.Fprintf(out, "\n%s\n", strings.Repeat("─", 63))
+	_, _ = fmt.Fprintf(out, "%s\n", strings.Repeat("─", 63))
 	_, _ = fmt.Fprintf(out, "Summary:\n")
 	_, _ = fmt.Fprintf(out, "  Total devices            : %d\n", len(graph.nodes))
 	_, _ = fmt.Fprintf(out, "  Rendered forest edges    : %d\n", treeEdgeCount)

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -11,6 +11,8 @@ import (
 	"jb.favre/mikrotik-fleet-autopilot/common/lldp"
 )
 
+const mfaNodeName = "mfa"
+
 type topologyNode struct {
 	name        string
 	isSource    bool
@@ -36,7 +38,7 @@ type topologyGraph struct {
 	nextFirstSeen int
 }
 
-func outputTopology(out io.Writer, topo *topology) error {
+func outputTopology(out io.Writer, topo *topology, connectedTo string) error {
 	if len(topo.errors) > 0 {
 		if _, werr := fmt.Fprintf(out, "Discovery Errors:\n"); werr != nil {
 			return werr
@@ -79,7 +81,10 @@ func outputTopology(out io.Writer, topo *topology) error {
 		return nil
 	}
 
-	graph := buildTopologyGraph(topo.results, topo.orderedHosts)
+	graph, err := buildTopologyGraph(topo.results, topo.orderedHosts, connectedTo)
+	if err != nil {
+		return err
+	}
 	slog.Info("topology graph built", "vertices", len(graph.nodes))
 
 	if _, werr := fmt.Fprintf(out, "LLDP Topology Graph\n"); werr != nil {
@@ -95,7 +100,7 @@ func outputTopology(out io.Writer, topo *topology) error {
 	return nil
 }
 
-func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []string) *topologyGraph {
+func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []string, connectedTo string) (*topologyGraph, error) {
 	graph := &topologyGraph{
 		g:          simple.NewUndirectedGraph(),
 		nodes:      make(map[string]*topologyNode),
@@ -135,7 +140,23 @@ func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []str
 		}
 	}
 
-	return graph
+	if connectedTo == "" {
+		return graph, nil
+	}
+
+	if _, ok := graph.nodes[connectedTo]; !ok {
+		return nil, fmt.Errorf("connected-to target %q was not discovered; use a discovered device identity", connectedTo)
+	}
+
+	// mfa is a synthetic graph-only node representing the computer running the tool.
+	// It must never be added to discovery inputs or any SSH connection path.
+	mfaNode := graph.getOrCreateNode(mfaNodeName, false, -1)
+	graph.addLink(mfaNode.name, connectedTo, &linkDetail{
+		from: mfaNode.name,
+		to:   connectedTo,
+	})
+
+	return graph, nil
 }
 
 func (g *topologyGraph) getOrCreateNode(name string, isSource bool, sourceOrder int) *topologyNode {
@@ -209,7 +230,7 @@ func (w *errorTrackingWriter) Write(p []byte) (int, error) {
 func renderTopologyGraph(out io.Writer, graph *topologyGraph, orderedHosts []string) error {
 	trackedOut := &errorTrackingWriter{w: out}
 	components := connectedComponents(graph)
-	roots := selectRoots(graph, components, orderedHosts)
+	roots := selectRoots(graph, components, orderedHosts, preferredRoot(graph))
 
 	totalTreeEdges := 0
 	for i, root := range roots {
@@ -231,6 +252,13 @@ func renderTopologyGraph(out io.Writer, graph *topologyGraph, orderedHosts []str
 	}
 
 	return nil
+}
+
+func preferredRoot(graph *topologyGraph) string {
+	if _, ok := graph.nodes[mfaNodeName]; ok {
+		return mfaNodeName
+	}
+	return ""
 }
 
 func connectedComponents(graph *topologyGraph) [][]string {
@@ -271,9 +299,13 @@ func connectedComponents(graph *topologyGraph) [][]string {
 	return components
 }
 
-func selectRoots(graph *topologyGraph, components [][]string, orderedHosts []string) []string {
+func selectRoots(graph *topologyGraph, components [][]string, orderedHosts []string, preferred string) []string {
 	roots := make([]string, 0, len(components))
 	for _, component := range components {
+		if preferred != "" && componentContains(component, preferred) {
+			roots = append(roots, preferred)
+			continue
+		}
 		best := component[0]
 		for _, candidate := range component[1:] {
 			if betterNode(graph, candidate, best, orderedHosts) {
@@ -283,6 +315,15 @@ func selectRoots(graph *topologyGraph, components [][]string, orderedHosts []str
 		roots = append(roots, best)
 	}
 	return roots
+}
+
+func componentContains(component []string, target string) bool {
+	for _, name := range component {
+		if name == target {
+			return true
+		}
+	}
+	return false
 }
 
 func betterNode(graph *topologyGraph, left, right string, orderedHosts []string) bool {
@@ -388,7 +429,7 @@ func renderComponent(out io.Writer, graph *topologyGraph, component []string, ro
 	}
 
 	_, _ = fmt.Fprintf(out, "[%s]\n", graph.nodes[root].name)
-	renderChildren(out, graph, root, children, "")
+	renderChildren(out, graph, root, children, "  ")
 
 	crossLinks := make([]string, 0)
 	for pair, links := range graph.undirected {
@@ -413,13 +454,6 @@ func renderComponent(out io.Writer, graph *topologyGraph, component []string, ro
 	return treeEdges
 }
 
-func padRight(s string, width int) string {
-	if len(s) >= width {
-		return s
-	}
-	return s + strings.Repeat(" ", width-len(s))
-}
-
 func renderChildren(out io.Writer, graph *topologyGraph, parent string, children map[string][]string, indent string) {
 	kids := children[parent]
 	for i, child := range kids {
@@ -434,46 +468,47 @@ func renderChildren(out io.Writer, graph *topologyGraph, parent string, children
 		childName := graph.nodes[child].name
 		edges := edgeDetailsBetween(graph, parent, child)
 
-		if len(edges) == 0 {
-			// No edge details (edge came from peer side only) — print node label only
-			_, _ = fmt.Fprintf(out, "%s%s[%s]\n", indent, branch, childName)
+		_, _ = fmt.Fprintf(out, "%s%s[%s]\n", indent, branch, childName)
+
+		// Filter renderable edges (skip if both interfaces are empty)
+		renderableEdges := make([]*linkDetail, 0)
+		for _, edge := range edges {
+			local := strings.TrimSpace(edge.localInterface)
+			remote := strings.TrimSpace(edge.remoteIface)
+			if local == "" && remote == "" {
+				continue
+			}
+			renderableEdges = append(renderableEdges, edge)
+		}
+
+		if len(renderableEdges) == 0 {
+			// No edge details (edge came from peer side only) — render descendants only.
 			renderChildren(out, graph, child, children, indent+vertBar+"   ")
 			continue
 		}
 
-		maxLocalLen := 0
-		for _, e := range edges {
-			if len(e.localInterface) > maxLocalLen {
-				maxLocalLen = len(e.localInterface)
+		// Determine detail connector: vertical bar only if this node has child devices to follow
+		hasChildren := len(children[child]) > 0
+		detailConnector := " "
+		if hasChildren {
+			detailConnector = "│"
+		}
+
+		// Print via lines with detail connector
+		for _, edge := range renderableEdges {
+			local := strings.TrimSpace(edge.localInterface)
+			remote := strings.TrimSpace(edge.remoteIface)
+			if local == "" {
+				local = "?"
 			}
+			if remote == "" {
+				remote = "?"
+			}
+			_, _ = fmt.Fprintf(out, "%s%s   %s  via %s ↔ %s\n", indent, vertBar, detailConnector, local, remote)
 		}
+		_, _ = fmt.Fprintf(out, "%s%s   %s\n", indent, vertBar, detailConnector)
 
-		// First edge: branch + localIface → [child] ← remoteIface
-		_, _ = fmt.Fprintf(out, "%s%s%s → [%s] ← %s\n",
-			indent, branch,
-			padRight(edges[0].localInterface, maxLocalLen),
-			childName,
-			edges[0].remoteIface,
-		)
-
-		// Additional parallel edges: aligned continuation lines
-		// "←" must be at the same column as on the first edge line.
-		// First-line "←" col  = len(indent) + 3 + maxLocalLen + 4 + len(childName) + 2
-		// Continuation prefix = len(indent) + 1(vertBar) + 2("  ") + maxLocalLen
-		// Fill to align       = len(childName) + 6
-		for _, edge := range edges[1:] {
-			_, _ = fmt.Fprintf(out, "%s%s  %s%s← %s\n",
-				indent, vertBar,
-				padRight(edge.localInterface, maxLocalLen),
-				strings.Repeat(" ", len(childName)+6),
-				edge.remoteIface,
-			)
-		}
-
-		// nextIndent positions grandchildren's branch char under "[" of [child]
-		// "[" col = len(indent) + 3(branch) + maxLocalLen + 3(" → ") = len(indent) + maxLocalLen + 6
-		// nextIndent = indent + vertBar(1) + spaces(maxLocalLen+5)  →  branch lands at col maxLocalLen+6 ✓
-		nextIndent := indent + vertBar + strings.Repeat(" ", maxLocalLen+5)
+		nextIndent := indent + vertBar + "   "
 		renderChildren(out, graph, child, children, nextIndent)
 	}
 }

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -584,6 +584,6 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int) {
 	_, _ = fmt.Fprintf(out, "\n%s\n", strings.Repeat("─", 63))
 	_, _ = fmt.Fprintf(out, "Summary:\n")
 	_, _ = fmt.Fprintf(out, "  Total devices            : %d\n", len(graph.nodes))
-	_, _ = fmt.Fprintf(out, "  Mikrotik devices         : %d\n", treeEdgeCount)
-	_, _ = fmt.Fprintf(out, "  Distinct LLDP adjacencies: %d\n", totalLinks)
+	_, _ = fmt.Fprintf(out, "  Rendered forest edges    : %d\n", treeEdgeCount)
+	_, _ = fmt.Fprintf(out, "  Stored LLDP records      : %d\n", totalLinks)
 }

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -581,8 +581,7 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int) {
 
 	_, _ = fmt.Fprintf(out, "\n%s\n", strings.Repeat("─", 63))
 	_, _ = fmt.Fprintf(out, "Summary:\n")
-	_, _ = fmt.Fprintf(out, "  Devices: %d\n", len(graph.nodes))
-	_, _ = fmt.Fprintf(out, "  Total link entries: %d\n", totalLinks)
-	_, _ = fmt.Fprintf(out, "  Tree edges: %d\n", treeEdgeCount)
-	_, _ = fmt.Fprintf(out, "  Cross-link pairs: %d\n", len(graph.undirected)-treeEdgeCount)
+	_, _ = fmt.Fprintf(out, "  Total devices            : %d\n", len(graph.nodes))
+	_, _ = fmt.Fprintf(out, "  Mikrotik devices         : %d\n", treeEdgeCount)
+	_, _ = fmt.Fprintf(out, "  Distinct LLDP adjacencies: %d\n", totalLinks)
 }

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -506,7 +506,9 @@ func renderChildren(out io.Writer, graph *topologyGraph, parent string, children
 			}
 			_, _ = fmt.Fprintf(out, "%s%s   %s  via %s ↔ %s\n", indent, vertBar, detailConnector, local, remote)
 		}
-		_, _ = fmt.Fprintf(out, "%s%s   %s\n", indent, vertBar, detailConnector)
+		if vertBar != " " || detailConnector != " " {
+			_, _ = fmt.Fprintf(out, "%s%s   %s\n", indent, vertBar, detailConnector)
+		}
 
 		nextIndent := indent + vertBar + "   "
 		renderChildren(out, graph, child, children, nextIndent)

--- a/common/lldp/parser.go
+++ b/common/lldp/parser.go
@@ -192,29 +192,30 @@ func newNeighbor(index int, fields map[string]string) (*Neighbor, error) {
 	}
 
 	n := &Neighbor{
-		Index:               index,
-		Identity:            identity,
-		Platform:            getStringField(fields, "platform"),
-		Version:             getStringField(fields, "version"),
-		Board:               getStringField(fields, "board"),
-		Address:             getStringField(fields, "address"),
-		Address6:            getStringField(fields, "address6"),
-		MacAddress:          getStringField(fields, "mac-address"),
-		SystemDescription:   getStringField(fields, "system-description"),
-		SystemCaps:          parseCommaSeparated(getStringField(fields, "system-caps")),
-		SystemCapsEnabled:   parseCommaSeparated(getStringField(fields, "system-caps-enabled")),
-		DiscoveredBy:        parseCommaSeparated(getStringField(fields, "discovered-by")),
-		Age:                 getStringField(fields, "age"),
-		Uptime:              getStringField(fields, "uptime"),
-		SoftwareID:          getStringField(fields, "software-id"),
-		Unpack:              getStringField(fields, "unpack"),
-		IPv6Enabled:         getStringField(fields, "ipv6") == "yes",
-		LocalInterfaceChain: getStringField(fields, "interface"),
-		RemoteInterface:     getStringField(fields, "interface-name"),
+		Index:                index,
+		Identity:             identity,
+		Platform:             getStringField(fields, "platform"),
+		Version:              getStringField(fields, "version"),
+		Board:                getStringField(fields, "board"),
+		Address:              getStringField(fields, "address"),
+		Address6:             getStringField(fields, "address6"),
+		MacAddress:           getStringField(fields, "mac-address"),
+		SystemDescription:    getStringField(fields, "system-description"),
+		SystemCaps:           parseCommaSeparated(getStringField(fields, "system-caps")),
+		SystemCapsEnabled:    parseCommaSeparated(getStringField(fields, "system-caps-enabled")),
+		DiscoveredBy:         parseCommaSeparated(getStringField(fields, "discovered-by")),
+		Age:                  getStringField(fields, "age"),
+		Uptime:               getStringField(fields, "uptime"),
+		SoftwareID:           getStringField(fields, "software-id"),
+		Unpack:               getStringField(fields, "unpack"),
+		IPv6Enabled:          getStringField(fields, "ipv6") == "yes",
+		LocalInterfaceChain:  getStringField(fields, "interface"),
+		RemoteInterfaceChain: getStringField(fields, "interface-name"),
 	}
 
 	// Extract physical interface from the chain
 	n.LocalInterface = extractLocalInterface(n.LocalInterfaceChain)
+	n.RemoteInterface = extractRemoteInterface(n.RemoteInterfaceChain)
 
 	return n, nil
 }
@@ -252,6 +253,19 @@ func extractLocalInterface(chain string) string {
 	parts := strings.Split(chain, ",")
 	if len(parts) > 0 {
 		return strings.TrimSpace(parts[0])
+	}
+	return ""
+}
+
+// extractRemoteInterface extracts the physical interface from a chain like "br-lan/ether1"
+// Returns the last component after the slash
+func extractRemoteInterface(chain string) string {
+	if chain == "" {
+		return ""
+	}
+	parts := strings.Split(chain, "/")
+	if len(parts) > 0 {
+		return strings.TrimSpace(parts[len(parts)-1])
 	}
 	return ""
 }

--- a/common/lldp/parser.go
+++ b/common/lldp/parser.go
@@ -254,7 +254,7 @@ func extractLocalInterface(chain string) string {
 	if len(parts) > 0 {
 		return strings.TrimSpace(parts[0])
 	}
-	return ""
+	return strings.TrimSpace(chain)
 }
 
 // extractRemoteInterface extracts the physical interface from a chain like "br-lan/ether1"
@@ -267,5 +267,5 @@ func extractRemoteInterface(chain string) string {
 	if len(parts) > 0 {
 		return strings.TrimSpace(parts[len(parts)-1])
 	}
-	return ""
+	return strings.TrimSpace(chain)
 }

--- a/common/lldp/parser_test.go
+++ b/common/lldp/parser_test.go
@@ -113,6 +113,27 @@ func TestExtractLocalInterface_Empty(t *testing.T) {
 	}
 }
 
+func TestExtractRemoteInterface_ChainWithBridge(t *testing.T) {
+	iface := extractRemoteInterface("br-lan/sfp-sfpplus3")
+	if iface != "sfp-sfpplus3" {
+		t.Errorf("extractRemoteInterface = %q, want sfp-sfpplus3", iface)
+	}
+}
+
+func TestExtractRemoteInterface_BondChain(t *testing.T) {
+	iface := extractRemoteInterface("br-lan/bond0/ether9")
+	if iface != "ether9" {
+		t.Errorf("extractRemoteInterface = %q, want ether9", iface)
+	}
+}
+
+func TestExtractRemoteInterface_Empty(t *testing.T) {
+	iface := extractRemoteInterface("")
+	if iface != "" {
+		t.Errorf("extractRemoteInterface = %q, want empty", iface)
+	}
+}
+
 func TestParseCommaSeparated_Single(t *testing.T) {
 	caps := parseCommaSeparated("bridge")
 	if len(caps) != 1 || caps[0] != "bridge" {

--- a/common/lldp/types.go
+++ b/common/lldp/types.go
@@ -11,7 +11,8 @@ type Neighbor struct {
 	LocalInterfaceChain string // full chain: "sfp-sfpplus3,br-lan"
 
 	// Remote interface information
-	RemoteInterface string // interface-name from neighbor perspective
+	RemoteInterface      string // extracted last part: "ether1"
+	RemoteInterfaceChain string // full chain: "br-lan/ether1"
 
 	// Neighbor device identity
 	Identity string // FQDN of neighbor device


### PR DESCRIPTION
This pull request adds support for visualizing the local computer (as a synthetic "mfa" node) in the LLDP topology graph, showing it as connected to a specified discovered device. The changes include updates to the CLI, core logic, and output rendering, along with comprehensive new tests to ensure correct behavior and error handling for this feature.

**New Feature: Synthetic "mfa" Node in Topology**

* Added a `--connected-to` CLI option to the `discover` command, allowing users to display the local computer as a node connected to a discovered device in the topology graph. (`README.md`, `cmd/discover/discover.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R51) [[2]](diffhunk://#diff-0c5456d728a7248d77e4857f61e37b243c06a98d3792258262eb9b34043b853eR20-R34)
* Implemented logic to add a synthetic "mfa" node to the topology graph, validating that the target exists and ensuring the synthetic node is never used as an SSH target. (`cmd/discover/output.go`) [[1]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135R14-R15) [[2]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L138-R159)

**Output and Graph Rendering Enhancements**

* Modified `outputTopology` and related functions to handle the synthetic node, ensuring it is rendered as the root when present, and improved the rendering of interface lines for links. (`cmd/discover/output.go`) [[1]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L39-R41) [[2]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L82-R87) [[3]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135R257-R263) [[4]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L274-R308)

**Testing Improvements**

* Added extensive tests for the new `--connected-to` feature, including correct rendering, error handling for unknown targets, and validation that SSH connections are not attempted to the synthetic node. (`cmd/discover/discover_test.go`)

**Internal Refactoring**

* Refactored connection logic to allow test injection of SSH connections and made minor code cleanups to support new features. (`cmd/discover/discover.go`, `cmd/discover/output.go`) [[1]](diffhunk://#diff-0c5456d728a7248d77e4857f61e37b243c06a98d3792258262eb9b34043b853eL59-R67) [[2]](diffhunk://#diff-0c5456d728a7248d77e4857f61e37b243c06a98d3792258262eb9b34043b853eL81-R89) [[3]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L212-R233) [[4]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135R320-R328) [[5]](diffhunk://#diff-7957f0915b16d919c55f72ec2240abbead8f2608477eb8e3dde6bde127afc135L416-L422)

These changes collectively make the topology discovery more flexible and informative, especially for users wanting to visualize their own system in the network graph.