### PR TITLE
feat: Add MNDP discovery support to the discover command (#121)

### DIFF
--- a/cmd/discover/discover.go
+++ b/cmd/discover/discover.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/lldp"
+	"jb.favre/mikrotik-fleet-autopilot/common/mndp"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 )
 
@@ -31,40 +32,67 @@ var Command = []*cli.Command{
 
 var createSSHConnection = ssh.CreateConnection
 
+// listenMNDP is the MNDP listener function; injectable for testing.
+var listenMNDP = mndp.Listen
+
 func runDiscoverForHosts(ctx context.Context, out io.Writer, connectedTo string) error {
-	// Get global config
 	cfg, err := core.GetConfig(ctx)
 	if err != nil {
-		slog.Error("failed to get config", "error", err)
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	if len(cfg.Hosts) == 0 {
+	hosts := cfg.Hosts
+	var mndpByIP map[string]*mndp.Device
+	var ipToIdentity map[string]string
+
+	if cfg.UseMNDP {
+		slog.Info("starting MNDP discovery", "interface", cfg.Interface, "timeout", cfg.MNDPTimeout)
+		devices, err := listenMNDP(ctx, cfg.Interface, cfg.MNDPTimeout)
+		if err != nil {
+			slog.Warn("MNDP discovery failed", "error", err)
+			// non-fatal: continue with empty host list (will error below)
+		}
+		mndpByIP = make(map[string]*mndp.Device, len(devices))
+		ipToIdentity = make(map[string]string, len(devices))
+		for _, d := range devices {
+			if d.IPv4Address != "" {
+				mndpByIP[d.IPv4Address] = d
+				ipToIdentity[d.IPv4Address] = d.Identity
+			}
+		}
+		// Build ordered host list from MNDP results (already sorted by Identity in listener)
+		for _, d := range devices {
+			if d.IPv4Address != "" {
+				hosts = append(hosts, d.IPv4Address)
+			}
+		}
+		slog.Info("MNDP discovery complete", "devices", len(devices), "addressable", len(hosts))
+	}
+
+	if len(hosts) == 0 {
 		return fmt.Errorf("no hosts configured for discovery")
 	}
 
-	slog.Info("starting LLDP discovery", "hosts", len(cfg.Hosts))
+	slog.Info("starting LLDP discovery", "hosts", len(hosts))
 
-	// Discover neighbors from all hosts
-	topology, err := discoverTopology(ctx, cfg.Hosts)
+	topo, err := discoverTopology(ctx, hosts)
 	if err != nil {
-		slog.Error("discovery failed", "error", err)
 		return fmt.Errorf("discovery failed: %w", err)
 	}
+	topo.mndpByIP = mndpByIP
+	topo.ipToIdentity = ipToIdentity
 
-	// Log summary before rendering
 	totalNeighbors := 0
-	for _, result := range topology.results {
+	for _, result := range topo.results {
 		totalNeighbors += len(result.Neighbors)
 	}
 	slog.Info("discovery complete",
-		"hosts_ok", len(topology.results),
-		"hosts_err", len(topology.errors),
+		"hosts_ok", len(topo.results),
+		"hosts_err", len(topo.errors),
 		"total_neighbors", totalNeighbors,
 	)
 
-	// Render output
-	return outputTopology(out, topology, connectedTo)
+	return outputTopology(out, topo, connectedTo)
 }
 
 // topology holds discovery results indexed by source host
@@ -72,6 +100,8 @@ type topology struct {
 	orderedHosts []string
 	results      map[string]*lldp.ParseResult
 	errors       map[string]error
+	mndpByIP     map[string]*mndp.Device // IPv4Address → Device
+	ipToIdentity map[string]string       // IPv4Address → MNDP Identity
 }
 
 func discoverTopology(ctx context.Context, hosts []string) (*topology, error) {

--- a/cmd/discover/discover_test.go
+++ b/cmd/discover/discover_test.go
@@ -679,6 +679,43 @@ func TestBuildTopologyGraph_ConnectedToSupportsMNDPSourceIP(t *testing.T) {
 	}
 }
 
+func TestBuildTopologyGraph_MNDPDuplicateIdentityDisambiguatedByHost(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"192.168.1.1", "192.168.1.2"},
+		results: map[string]*lldp.ParseResult{
+			"192.168.1.1": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors: map[string]error{
+			"192.168.1.2": errors.New("ssh failed"),
+		},
+		ipToIdentity: map[string]string{
+			"192.168.1.1": "router.home",
+			"192.168.1.2": "router.home",
+		},
+	}
+
+	graph, err := buildTopologyGraph(topo, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
+
+	name1 := "router.home (192.168.1.1)"
+	name2 := "router.home (192.168.1.2)"
+	if _, ok := graph.nodes[name1]; !ok {
+		t.Fatalf("expected disambiguated node %q to exist", name1)
+	}
+	if _, ok := graph.nodes[name2]; !ok {
+		t.Fatalf("expected disambiguated node %q to exist", name2)
+	}
+
+	if n := graph.nodes[name1]; n.sshReachable == nil || !*n.sshReachable {
+		t.Fatalf("expected %q to be marked SSH reachable", name1)
+	}
+	if n := graph.nodes[name2]; n.sshReachable == nil || *n.sshReachable {
+		t.Fatalf("expected %q to be marked SSH unreachable", name2)
+	}
+}
+
 func TestBuildTopologyGraph_SSHReachabilityMarked(t *testing.T) {
 	results := map[string]*lldp.ParseResult{
 		"router1": {Neighbors: []*lldp.Neighbor{}},

--- a/cmd/discover/discover_test.go
+++ b/cmd/discover/discover_test.go
@@ -3,13 +3,16 @@ package discover
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/lldp"
+	"jb.favre/mikrotik-fleet-autopilot/common/mndp"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
 )
 
@@ -46,7 +49,12 @@ func TestBuildTopologyGraph_Basic(t *testing.T) {
 		},
 	}
 
-	graph, err := buildTopologyGraph(results, []string{"device1", "device2"}, "")
+	topo := &topology{
+		orderedHosts: []string{"device1", "device2"},
+		results:      results,
+		errors:       map[string]error{},
+	}
+	graph, err := buildTopologyGraph(topo, "")
 	if err != nil {
 		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
 	}
@@ -81,7 +89,12 @@ func TestBuildTopologyGraph_RedundantLinksMultiplicity(t *testing.T) {
 		},
 	}
 
-	graph, err := buildTopologyGraph(results, []string{"source"}, "")
+	topo := &topology{
+		orderedHosts: []string{"source"},
+		results:      results,
+		errors:       map[string]error{},
+	}
+	graph, err := buildTopologyGraph(topo, "")
 	if err != nil {
 		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
 	}
@@ -103,7 +116,12 @@ func TestSelectRoots_PrefersHigherDegree(t *testing.T) {
 		"c": {Neighbors: []*lldp.Neighbor{}},
 	}
 
-	graph, err := buildTopologyGraph(results, []string{"a", "b", "c"}, "")
+	topo := &topology{
+		orderedHosts: []string{"a", "b", "c"},
+		results:      results,
+		errors:       map[string]error{},
+	}
+	graph, err := buildTopologyGraph(topo, "")
 	if err != nil {
 		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
 	}
@@ -127,7 +145,12 @@ func TestBuildTopologyGraph_ConnectedToAddsMFANode(t *testing.T) {
 		"router2": {Neighbors: []*lldp.Neighbor{}},
 	}
 
-	graph, err := buildTopologyGraph(results, []string{"router1", "router2"}, "router2")
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results:      results,
+		errors:       map[string]error{},
+	}
+	graph, err := buildTopologyGraph(topo, "router2")
 	if err != nil {
 		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
 	}
@@ -158,7 +181,12 @@ func TestBuildTopologyGraph_ConnectedToUnknownTargetFails(t *testing.T) {
 		"router1": {Neighbors: []*lldp.Neighbor{}},
 	}
 
-	_, err := buildTopologyGraph(results, []string{"router1"}, "router2")
+	topo := &topology{
+		orderedHosts: []string{"router1"},
+		results:      results,
+		errors:       map[string]error{},
+	}
+	_, err := buildTopologyGraph(topo, "router2")
 	if err == nil {
 		t.Fatal("expected error for unknown connected-to target, got nil")
 	}
@@ -490,5 +518,216 @@ func TestOutputTopology_UpgradeSummaryMetrics(t *testing.T) {
 	}
 	if !strings.Contains(output, "Max wave parallelism") {
 		t.Fatalf("expected summary to contain Max wave parallelism metric, got:\n%s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MNDP path tests
+// ---------------------------------------------------------------------------
+
+func TestRunDiscoverForHosts_MNDPSuccessfulDiscovery(t *testing.T) {
+	// Inject a mock MNDP listener that returns one device with an IPv4 address
+	originalListen := listenMNDP
+	listenMNDP = func(_ context.Context, _ string, _ time.Duration) ([]*mndp.Device, error) {
+		return []*mndp.Device{
+			{MACAddress: "aa:bb:cc:dd:ee:ff", Identity: "router.home", IPv4Address: "192.168.1.1"},
+		}, nil
+	}
+	defer func() { listenMNDP = originalListen }()
+
+	// SSH stub returns empty LLDP output
+	originalSSH := createSSHConnection
+	createSSHConnection = func(_ context.Context, _ string) (ssh.RunnerInterface, error) {
+		return &stubRunner{runOutput: ""}, nil
+	}
+	defer func() { createSSHConnection = originalSSH }()
+
+	cfg := &core.Config{UseMNDP: true, MNDPTimeout: 5 * time.Second}
+	ctx := context.WithValue(context.Background(), core.ConfigKey, cfg)
+
+	var out bytes.Buffer
+	if err := runDiscoverForHosts(ctx, &out, ""); err != nil {
+		t.Fatalf("runDiscoverForHosts() unexpected error = %v", err)
+	}
+	// The topology should display "router.home" (MNDP identity), not the bare IP
+	if !strings.Contains(out.String(), "router.home") {
+		t.Errorf("expected output to contain MNDP identity 'router.home', got:\n%s", out.String())
+	}
+}
+
+func TestRunDiscoverForHosts_MNDPSSHFails(t *testing.T) {
+	// MNDP returns a device
+	originalListen := listenMNDP
+	listenMNDP = func(_ context.Context, _ string, _ time.Duration) ([]*mndp.Device, error) {
+		return []*mndp.Device{
+			{MACAddress: "aa:bb:cc:dd:ee:ff", Identity: "router.home", IPv4Address: "192.168.1.1"},
+		}, nil
+	}
+	defer func() { listenMNDP = originalListen }()
+
+	// SSH connection fails
+	originalSSH := createSSHConnection
+	createSSHConnection = func(_ context.Context, _ string) (ssh.RunnerInterface, error) {
+		return nil, errors.New("connection refused")
+	}
+	defer func() { createSSHConnection = originalSSH }()
+
+	cfg := &core.Config{UseMNDP: true, MNDPTimeout: 5 * time.Second}
+	ctx := context.WithValue(context.Background(), core.ConfigKey, cfg)
+
+	var out bytes.Buffer
+	// Should not return an error (SSH failure is recorded, not fatal)
+	if err := runDiscoverForHosts(ctx, &out, ""); err != nil {
+		t.Fatalf("runDiscoverForHosts() unexpected error = %v", err)
+	}
+	// The error section should appear in the output
+	output := out.String()
+	if !strings.Contains(output, "Discovery Errors") {
+		t.Errorf("expected output to contain 'Discovery Errors', got:\n%s", output)
+	}
+}
+
+func TestRunDiscoverForHosts_MNDPZeroDevices(t *testing.T) {
+	// MNDP returns no devices
+	originalListen := listenMNDP
+	listenMNDP = func(_ context.Context, _ string, _ time.Duration) ([]*mndp.Device, error) {
+		return []*mndp.Device{}, nil
+	}
+	defer func() { listenMNDP = originalListen }()
+
+	cfg := &core.Config{UseMNDP: true, MNDPTimeout: 5 * time.Second}
+	ctx := context.WithValue(context.Background(), core.ConfigKey, cfg)
+
+	err := runDiscoverForHosts(ctx, io.Discard, "")
+	if err == nil {
+		t.Fatal("runDiscoverForHosts() expected error for zero MNDP devices, got nil")
+	}
+	if !strings.Contains(err.Error(), "no hosts") {
+		t.Errorf("expected 'no hosts' error, got: %v", err)
+	}
+}
+
+func TestRunDiscoverForHosts_MNDPListenError(t *testing.T) {
+	// MNDP listener returns an error
+	originalListen := listenMNDP
+	listenMNDP = func(_ context.Context, _ string, _ time.Duration) ([]*mndp.Device, error) {
+		return nil, errors.New("network unreachable")
+	}
+	defer func() { listenMNDP = originalListen }()
+
+	cfg := &core.Config{UseMNDP: true, MNDPTimeout: 5 * time.Second}
+	ctx := context.WithValue(context.Background(), core.ConfigKey, cfg)
+
+	err := runDiscoverForHosts(ctx, io.Discard, "")
+	// MNDP error is non-fatal (warn + empty host list → "no hosts" error)
+	if err == nil {
+		t.Fatal("runDiscoverForHosts() expected error after MNDP failure with empty hosts, got nil")
+	}
+	if !strings.Contains(err.Error(), "no hosts") {
+		t.Errorf("expected 'no hosts' error after MNDP failure, got: %v", err)
+	}
+}
+
+func TestBuildTopologyGraph_MNDPIdentityAliasing(t *testing.T) {
+	// When ipToIdentity maps an IP to an identity, the node should use the identity as its name
+	results := map[string]*lldp.ParseResult{
+		"192.168.1.1": {
+			Neighbors: []*lldp.Neighbor{
+				{Identity: "switch1"},
+			},
+		},
+	}
+
+	topo := &topology{
+		orderedHosts: []string{"192.168.1.1"},
+		results:      results,
+		errors:       map[string]error{},
+		ipToIdentity: map[string]string{"192.168.1.1": "router.home"},
+	}
+	graph, err := buildTopologyGraph(topo, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
+
+	// The node should be named "router.home", not "192.168.1.1"
+	if _, ok := graph.nodes["router.home"]; !ok {
+		t.Errorf("expected node 'router.home' (from MNDP identity), got nodes: %v", graph.nodes)
+	}
+	if _, ok := graph.nodes["192.168.1.1"]; ok {
+		t.Errorf("expected bare IP '192.168.1.1' to be replaced by MNDP identity")
+	}
+}
+
+func TestBuildTopologyGraph_SSHReachabilityMarked(t *testing.T) {
+	results := map[string]*lldp.ParseResult{
+		"router1": {Neighbors: []*lldp.Neighbor{}},
+	}
+	errs := map[string]error{
+		"router2": errors.New("connection refused"),
+	}
+
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results:      results,
+		errors:       errs,
+	}
+	graph, err := buildTopologyGraph(topo, "")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
+
+	// router1 had a result → sshReachable = true
+	if n, ok := graph.nodes["router1"]; !ok || n.sshReachable == nil || !*n.sshReachable {
+		t.Errorf("expected router1 to be SSH reachable")
+	}
+	// router2 had an error → sshReachable = false
+	if n, ok := graph.nodes["router2"]; !ok || n.sshReachable == nil || *n.sshReachable {
+		t.Errorf("expected router2 to be SSH unreachable")
+	}
+}
+
+func TestOutputTopology_UnreachableDeviceRenderedWithPrefix(t *testing.T) {
+	// router2 is in ordered hosts but SSH failed
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {Neighbors: []*lldp.Neighbor{{Identity: "router2"}}},
+		},
+		errors: map[string]error{
+			"router2": errors.New("connection refused"),
+		},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	output := out.String()
+	// router2 has sshReachable=false → should appear with ❓ prefix in the tree
+	if !strings.Contains(output, "❓") {
+		t.Errorf("expected ❓ prefix for SSH-unreachable device, got:\n%s", output)
+	}
+}
+
+func TestOutputTopology_UnreachableCountInSummary(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"router1", "router2"},
+		results: map[string]*lldp.ParseResult{
+			"router1": {Neighbors: []*lldp.Neighbor{{Identity: "router2"}}},
+		},
+		errors: map[string]error{
+			"router2": errors.New("connection refused"),
+		},
+	}
+
+	var out bytes.Buffer
+	if err := outputTopology(&out, topo, ""); err != nil {
+		t.Fatalf("outputTopology() unexpected error = %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Unreachable devices") {
+		t.Errorf("expected 'Unreachable devices' in summary, got:\n%s", output)
 	}
 }

--- a/cmd/discover/discover_test.go
+++ b/cmd/discover/discover_test.go
@@ -658,6 +658,27 @@ func TestBuildTopologyGraph_MNDPIdentityAliasing(t *testing.T) {
 	}
 }
 
+func TestBuildTopologyGraph_ConnectedToSupportsMNDPSourceIP(t *testing.T) {
+	topo := &topology{
+		orderedHosts: []string{"192.168.1.1"},
+		results: map[string]*lldp.ParseResult{
+			"192.168.1.1": {Neighbors: []*lldp.Neighbor{}},
+		},
+		errors:       map[string]error{},
+		ipToIdentity: map[string]string{"192.168.1.1": "router.home"},
+	}
+
+	graph, err := buildTopologyGraph(topo, "192.168.1.1")
+	if err != nil {
+		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
+	}
+
+	edges := graph.outgoing[mfaNodeName]["router.home"]
+	if len(edges) != 1 {
+		t.Fatalf("expected synthetic edge from %s to router.home, got %d", mfaNodeName, len(edges))
+	}
+}
+
 func TestBuildTopologyGraph_SSHReachabilityMarked(t *testing.T) {
 	results := map[string]*lldp.ParseResult{
 		"router1": {Neighbors: []*lldp.Neighbor{}},

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -191,7 +191,7 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		// are not part of orderedHosts (for example, external caller inputs).
 		if id, ok := topo.ipToIdentity[connectedTo]; ok && id != "" {
 			if identityHostCounts[id] > 1 {
-				return nil, fmt.Errorf("connected-to target %q resolves to a duplicate identity %q; use a specific source IP instead", connectedTo, id)
+				return nil, fmt.Errorf("connected-to target %q resolves to duplicate identity %q; choose one of the disambiguated source names (%s)", connectedTo, id, disambiguatedIdentityHint(id, topo.orderedHosts, topo.ipToIdentity))
 			}
 			canonicalConnectedTo = id
 		}
@@ -213,6 +213,16 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 	})
 
 	return graph, nil
+}
+
+func disambiguatedIdentityHint(identity string, orderedHosts []string, ipToIdentity map[string]string) string {
+	var names []string
+	for _, host := range orderedHosts {
+		if ipToIdentity[host] == identity {
+			names = append(names, fmt.Sprintf("%s (%s)", identity, host))
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 func (g *topologyGraph) getOrCreateNode(name string, isSource bool, sourceOrder int) *topologyNode {

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -9,17 +9,17 @@ import (
 	"strings"
 
 	"gonum.org/v1/gonum/graph/simple"
-	"jb.favre/mikrotik-fleet-autopilot/common/lldp"
 )
 
 const mfaNodeName = "mfa"
 
 type topologyNode struct {
-	name        string
-	isSource    bool
-	sourceOrder int
-	firstSeen   int
-	graphID     int64
+	name         string
+	isSource     bool
+	sourceOrder  int
+	firstSeen    int
+	graphID      int64
+	sshReachable *bool // nil = not attempted; &true = ok; &false = failed
 }
 
 type linkDetail struct {
@@ -82,7 +82,7 @@ func outputTopology(out io.Writer, topo *topology, connectedTo string) error {
 		return nil
 	}
 
-	graph, err := buildTopologyGraph(topo.results, topo.orderedHosts, connectedTo)
+	graph, err := buildTopologyGraph(topo, connectedTo)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func outputTopology(out io.Writer, topo *topology, connectedTo string) error {
 	return nil
 }
 
-func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []string, connectedTo string) (*topologyGraph, error) {
+func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, error) {
 	graph := &topologyGraph{
 		g:          simple.NewUndirectedGraph(),
 		nodes:      make(map[string]*topologyNode),
@@ -112,25 +112,52 @@ func buildTopologyGraph(results map[string]*lldp.ParseResult, orderedHosts []str
 		undirected: make(map[string][]*linkDetail),
 	}
 
-	hostOrder := make(map[string]int, len(orderedHosts))
-	for idx, host := range orderedHosts {
+	hostOrder := make(map[string]int, len(topo.orderedHosts))
+	for idx, host := range topo.orderedHosts {
 		hostOrder[host] = idx
-		graph.getOrCreateNode(host, true, idx)
+
+		// Resolve canonical name: prefer MNDP identity over bare IP
+		canonicalName := host
+		if topo.ipToIdentity != nil {
+			if id, ok := topo.ipToIdentity[host]; ok && id != "" {
+				canonicalName = id
+			}
+		}
+		node := graph.getOrCreateNode(canonicalName, true, idx)
+
+		// Mark SSH reachability
+		if _, failed := topo.errors[host]; failed {
+			f := false
+			node.sshReachable = &f
+		} else if _, ok := topo.results[host]; ok {
+			t := true
+			node.sshReachable = &t
+		}
+		// If neither result nor error exists for this host, sshReachable stays nil
 	}
 
-	for _, sourceHost := range orderedHosts {
-		result := results[sourceHost]
+	for _, sourceHost := range topo.orderedHosts {
+		result := topo.results[sourceHost]
 		if result == nil {
 			continue
 		}
-		sourceNode := graph.getOrCreateNode(sourceHost, true, hostOrder[sourceHost])
+		// Resolve canonical name for the source node
+		canonicalSource := sourceHost
+		if topo.ipToIdentity != nil {
+			if id, ok := topo.ipToIdentity[sourceHost]; ok && id != "" {
+				canonicalSource = id
+			}
+		}
+		sourceNode := graph.getOrCreateNode(canonicalSource, true, hostOrder[sourceHost])
 		for neighborIdx, neighbor := range result.Neighbors {
 			identity := strings.TrimSpace(neighbor.Identity)
 			localInterface := strings.TrimSpace(neighbor.LocalInterface)
 			// Avoid collapsing distinct neighbors with missing identity into a
 			// single shared "unknown" node by generating a scoped placeholder.
+			// We use canonicalSource (MNDP identity when available) so the
+			// placeholder matches the node name already used in the graph.
 			if identity == "" {
-				identity = fmt.Sprintf("unknown (%s:%s#%d)", sourceHost, localInterface, neighborIdx)
+				identity = fmt.Sprintf("unknown (%s:%s#%d)", canonicalSource, localInterface, neighborIdx)
 			}
 			destination := graph.getOrCreateNode(identity, false, -1)
 			graph.addLink(sourceNode.name, destination.name, &linkDetail{
@@ -402,7 +429,11 @@ func renderComponent(out io.Writer, graph *topologyGraph, component []string, ro
 		treeEdges[pairKey(p, child)] = true
 	}
 
-	_, _ = fmt.Fprintf(out, "[%s]\n", graph.nodes[root].name)
+	statusPrefix := ""
+	if n := graph.nodes[root]; n != nil && n.sshReachable != nil && !*n.sshReachable {
+		statusPrefix = "❓ "
+	}
+	_, _ = fmt.Fprintf(out, "[%s%s]\n", statusPrefix, graph.nodes[root].name)
 	renderChildren(out, graph, root, children, "  ")
 
 	crossLinks := make([]string, 0)
@@ -442,7 +473,11 @@ func renderChildren(out io.Writer, graph *topologyGraph, parent string, children
 		childName := graph.nodes[child].name
 		edges := edgeDetailsBetween(graph, parent, child)
 
-		_, _ = fmt.Fprintf(out, "%s%s[%s]\n", indent, branch, childName)
+		childStatusPrefix := ""
+		if n := graph.nodes[child]; n.sshReachable != nil && !*n.sshReachable {
+			childStatusPrefix = "❓ "
+		}
+		_, _ = fmt.Fprintf(out, "%s%s[%s%s]\n", indent, branch, childStatusPrefix, childName)
 
 		// Filter renderable edges (skip if both interfaces are empty)
 		renderableEdges := make([]*linkDetail, 0)
@@ -599,6 +634,16 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int, plan *
 	_, _ = fmt.Fprintf(out, "  Total devices        : %d\n", len(graph.nodes))
 	_, _ = fmt.Fprintf(out, "  Rendered forest edges: %d\n", treeEdgeCount)
 	_, _ = fmt.Fprintf(out, "  Stored LLDP records  : %d\n", totalLinks)
+
+	unreachable := 0
+	for _, node := range graph.nodes {
+		if node.sshReachable != nil && !*node.sshReachable {
+			unreachable++
+		}
+	}
+	if unreachable > 0 {
+		_, _ = fmt.Fprintf(out, "  Unreachable devices  : %d  (MNDP-visible, SSH failed)\n", unreachable)
+	}
 
 	if plan != nil {
 		upgradeableCount := 0

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -174,16 +174,23 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		return graph, nil
 	}
 
-	if _, ok := graph.nodes[connectedTo]; !ok {
+	canonicalConnectedTo := connectedTo
+	if topo.ipToIdentity != nil {
+		if id, ok := topo.ipToIdentity[connectedTo]; ok && id != "" {
+			canonicalConnectedTo = id
+		}
+	}
+
+	if _, ok := graph.nodes[canonicalConnectedTo]; !ok {
 		return nil, fmt.Errorf("connected-to target %q was not found in the topology; use a configured source host or a discovered device identity", connectedTo)
 	}
 
 	// mfa is a synthetic graph-only node representing the computer running the tool.
 	// It must never be added to discovery inputs or any SSH connection path.
 	mfaNode := graph.getOrCreateNode(mfaNodeName, false, -1)
-	graph.addLink(mfaNode.name, connectedTo, &linkDetail{
+	graph.addLink(mfaNode.name, canonicalConnectedTo, &linkDetail{
 		from: mfaNode.name,
-		to:   connectedTo,
+		to:   canonicalConnectedTo,
 	})
 
 	return graph, nil

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -687,7 +687,7 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int, plan *
 		}
 	}
 	if unreachable > 0 {
-		_, _ = fmt.Fprintf(out, "  Unreachable devices  : %d  (SSH failed)\n", unreachable)
+		_, _ = fmt.Fprintf(out, "  Unreachable devices  : %d  (MNDP-visible, SSH failed)\n", unreachable)
 	}
 
 	if plan != nil {

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -191,7 +191,13 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		// are not part of orderedHosts (for example, external caller inputs).
 		if id, ok := topo.ipToIdentity[connectedTo]; ok && id != "" {
 			if identityHostCounts[id] > 1 {
-				return nil, fmt.Errorf("connected-to target %q resolves to duplicate identity %q; choose one of the disambiguated source names (%s)", connectedTo, id, disambiguatedIdentityHint(id, topo.orderedHosts, topo.ipToIdentity))
+				hint := disambiguatedIdentityHint(id, topo.orderedHosts, topo.ipToIdentity)
+				return nil, fmt.Errorf(
+					"connected-to target %q resolves to duplicate identity %q; choose one source name: %s",
+					connectedTo,
+					id,
+					hint,
+				)
 			}
 			canonicalConnectedTo = id
 		}

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -228,6 +228,9 @@ func disambiguatedIdentityHint(identity string, orderedHosts []string, ipToIdent
 			names = append(names, fmt.Sprintf("%s (%s)", identity, host))
 		}
 	}
+	if len(names) == 0 {
+		return identity
+	}
 	return strings.Join(names, ", ")
 }
 

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -112,6 +112,17 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		undirected: make(map[string][]*linkDetail),
 	}
 
+	identityHostCounts := make(map[string]int)
+	for _, host := range topo.orderedHosts {
+		if topo.ipToIdentity == nil {
+			continue
+		}
+		if id, ok := topo.ipToIdentity[host]; ok && id != "" {
+			identityHostCounts[id]++
+		}
+	}
+
+	hostToNodeName := make(map[string]string, len(topo.orderedHosts))
 	hostOrder := make(map[string]int, len(topo.orderedHosts))
 	for idx, host := range topo.orderedHosts {
 		hostOrder[host] = idx
@@ -120,9 +131,14 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		canonicalName := host
 		if topo.ipToIdentity != nil {
 			if id, ok := topo.ipToIdentity[host]; ok && id != "" {
-				canonicalName = id
+				if identityHostCounts[id] > 1 {
+					canonicalName = fmt.Sprintf("%s (%s)", id, host)
+				} else {
+					canonicalName = id
+				}
 			}
 		}
+		hostToNodeName[host] = canonicalName
 		node := graph.getOrCreateNode(canonicalName, true, idx)
 
 		// Mark SSH reachability
@@ -141,13 +157,7 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 		if result == nil {
 			continue
 		}
-		// Resolve canonical name for the source node
-		canonicalSource := sourceHost
-		if topo.ipToIdentity != nil {
-			if id, ok := topo.ipToIdentity[sourceHost]; ok && id != "" {
-				canonicalSource = id
-			}
-		}
+		canonicalSource := hostToNodeName[sourceHost]
 		sourceNode := graph.getOrCreateNode(canonicalSource, true, hostOrder[sourceHost])
 		for neighborIdx, neighbor := range result.Neighbors {
 			identity := strings.TrimSpace(neighbor.Identity)
@@ -175,8 +185,13 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 	}
 
 	canonicalConnectedTo := connectedTo
-	if topo.ipToIdentity != nil {
+	if resolved, ok := hostToNodeName[connectedTo]; ok {
+		canonicalConnectedTo = resolved
+	} else if topo.ipToIdentity != nil {
 		if id, ok := topo.ipToIdentity[connectedTo]; ok && id != "" {
+			if identityHostCounts[id] > 1 {
+				return nil, fmt.Errorf("connected-to target %q resolves to a duplicate identity %q; use a specific source IP instead", connectedTo, id)
+			}
 			canonicalConnectedTo = id
 		}
 	}

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -182,6 +182,9 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 	}
 
 	if _, ok := graph.nodes[canonicalConnectedTo]; !ok {
+		if canonicalConnectedTo != connectedTo {
+			return nil, fmt.Errorf("connected-to target %q (resolved to %q) was not found in the topology; use a configured source host or a discovered device identity", connectedTo, canonicalConnectedTo)
+		}
 		return nil, fmt.Errorf("connected-to target %q was not found in the topology; use a configured source host or a discovered device identity", connectedTo)
 	}
 

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -113,12 +113,11 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 	}
 
 	identityHostCounts := make(map[string]int)
-	for _, host := range topo.orderedHosts {
-		if topo.ipToIdentity == nil {
-			continue
-		}
-		if id, ok := topo.ipToIdentity[host]; ok && id != "" {
-			identityHostCounts[id]++
+	if topo.ipToIdentity != nil {
+		for _, host := range topo.orderedHosts {
+			if id, ok := topo.ipToIdentity[host]; ok && id != "" {
+				identityHostCounts[id]++
+			}
 		}
 	}
 
@@ -188,6 +187,8 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 	if resolved, ok := hostToNodeName[connectedTo]; ok {
 		canonicalConnectedTo = resolved
 	} else if topo.ipToIdentity != nil {
+		// Fallback for IP values that can be canonicalized by MNDP identity but
+		// are not part of orderedHosts (for example, external caller inputs).
 		if id, ok := topo.ipToIdentity[connectedTo]; ok && id != "" {
 			if identityHostCounts[id] > 1 {
 				return nil, fmt.Errorf("connected-to target %q resolves to a duplicate identity %q; use a specific source IP instead", connectedTo, id)

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -183,7 +183,7 @@ func buildTopologyGraph(topo *topology, connectedTo string) (*topologyGraph, err
 
 	if _, ok := graph.nodes[canonicalConnectedTo]; !ok {
 		if canonicalConnectedTo != connectedTo {
-			return nil, fmt.Errorf("connected-to target %q (resolved to %q) was not found in the topology; use a configured source host or a discovered device identity", connectedTo, canonicalConnectedTo)
+			return nil, fmt.Errorf("connected-to target %q (resolved from IP to identity %q) was not found in the topology; use a configured source host or a discovered device identity", connectedTo, canonicalConnectedTo)
 		}
 		return nil, fmt.Errorf("connected-to target %q was not found in the topology; use a configured source host or a discovered device identity", connectedTo)
 	}

--- a/cmd/discover/output.go
+++ b/cmd/discover/output.go
@@ -642,7 +642,7 @@ func printSummary(out io.Writer, graph *topologyGraph, treeEdgeCount int, plan *
 		}
 	}
 	if unreachable > 0 {
-		_, _ = fmt.Fprintf(out, "  Unreachable devices  : %d  (MNDP-visible, SSH failed)\n", unreachable)
+		_, _ = fmt.Fprintf(out, "  Unreachable devices  : %d  (SSH failed)\n", unreachable)
 	}
 
 	if plan != nil {

--- a/cmd/discover/planner_test.go
+++ b/cmd/discover/planner_test.go
@@ -10,7 +10,12 @@ import (
 // from LLDP results and fails the test on any error.
 func buildGraphForPlannerTest(t *testing.T, results map[string]*lldp.ParseResult, orderedHosts []string, connectedTo string) *topologyGraph {
 	t.Helper()
-	graph, err := buildTopologyGraph(results, orderedHosts, connectedTo)
+	topo := &topology{
+		orderedHosts: orderedHosts,
+		results:      results,
+		errors:       map[string]error{},
+	}
+	graph, err := buildTopologyGraph(topo, connectedTo)
 	if err != nil {
 		t.Fatalf("buildTopologyGraph() unexpected error = %v", err)
 	}

--- a/common/core/config.go
+++ b/common/core/config.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"runtime"
+	"time"
 )
 
 type Config struct {
@@ -14,6 +15,9 @@ type Config struct {
 	EffectiveMaxConcurrent int
 	BufferedOutput         bool
 	PreferLiveMode         bool
+	Interface              string        // --interface: NIC name for MNDP (empty = all eligible)
+	UseMNDP                bool          // --mndp: use MNDP for host discovery
+	MNDPTimeout            time.Duration // --mndp-timeout: collection window
 }
 
 // ResolveMaxConcurrentHosts returns the effective host concurrency cap.

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -2,6 +2,7 @@ package mndp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -80,10 +81,27 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 			defer wg.Done()
 			defer func() { _ = conn.Close() }()
 
+			done := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = conn.Close()
+				case <-done:
+				}
+			}()
+			defer close(done)
+
 			buf := make([]byte, 4096)
 			for {
 				n, _, err := conn.ReadFrom(buf)
 				if err != nil {
+					if ctx.Err() != nil {
+						break
+					}
+					if errors.Is(err, net.ErrClosed) {
+						break
+					}
+
 					// Timeout or other error; stop reading this interface
 					break
 				}

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const listenReadPollInterval = 250 * time.Millisecond
+
 // Listen sends an MNDP probe on ifaceName (or all eligible interfaces when empty)
 // and collects responses for the duration of timeout.
 // Devices are deduplicated by MACAddress (last-seen wins).
@@ -81,7 +83,7 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 					break
 				}
 
-				readDeadline := time.Now().Add(250 * time.Millisecond)
+				readDeadline := time.Now().Add(listenReadPollInterval)
 				if readDeadline.After(deadline) {
 					readDeadline = deadline
 				}
@@ -92,7 +94,8 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 
 				n, _, err := conn.ReadFrom(buf)
 				if err != nil {
-					if ne, ok := err.(net.Error); ok && ne.Timeout() {
+					var ne net.Error
+					if errors.As(err, &ne) && ne.Timeout() {
 						now := time.Now()
 						if !now.Before(deadline) {
 							break

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -77,12 +77,18 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 			defer wg.Done()
 			defer func() { _ = conn.Close() }()
 
+			done := make(chan struct{})
+			defer close(done)
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = conn.Close()
+				case <-done:
+				}
+			}()
+
 			buf := make([]byte, 4096)
 			for {
-				if ctx.Err() != nil {
-					break
-				}
-
 				readDeadline := time.Now().Add(listenReadPollInterval)
 				if readDeadline.After(deadline) {
 					readDeadline = deadline

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -19,6 +19,10 @@ const listenReadPollInterval = 250 * time.Millisecond
 // Devices are deduplicated by MACAddress (last-seen wins).
 // Returns the deduplicated slice, sorted by Identity.
 func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*Device, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("mndp: timeout must be greater than 0")
+	}
+
 	var ifaces []net.Interface
 
 	if ifaceName != "" {
@@ -54,6 +58,9 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 	for _, iface := range ifaces {
 		ipv4, err := firstIPv4(iface)
 		if err != nil {
+			if ifaceName != "" {
+				return nil, fmt.Errorf("mndp: interface %q has no usable IPv4 address: %w", iface.Name, err)
+			}
 			slog.Debug("mndp: skipping interface (no IPv4)", "interface", iface.Name, "error", err)
 			continue
 		}
@@ -61,11 +68,18 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 		addr := ipv4 + ":5678"
 		conn, err := net.ListenPacket("udp4", addr)
 		if err != nil {
+			if ifaceName != "" {
+				return nil, fmt.Errorf("mndp: failed to bind to interface %q (%s): %w", iface.Name, addr, err)
+			}
 			slog.Debug("mndp: failed to bind on interface", "interface", iface.Name, "addr", addr, "error", err)
 			continue
 		}
 
 		if err := SendProbe(conn); err != nil {
+			if ifaceName != "" {
+				_ = conn.Close()
+				return nil, fmt.Errorf("mndp: failed to send probe on interface %q: %w", iface.Name, err)
+			}
 			slog.Debug("mndp: probe send failed", "interface", iface.Name, "error", err)
 			_ = conn.Close()
 			continue

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -102,8 +102,7 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 				if err != nil {
 					var ne net.Error
 					if errors.As(err, &ne) && ne.Timeout() {
-						now := time.Now()
-						if !now.Before(deadline) {
+						if !readDeadline.Before(deadline) {
 							break
 						}
 						continue

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -1,0 +1,163 @@
+package mndp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Listen sends an MNDP probe on ifaceName (or all eligible interfaces when empty)
+// and collects responses for the duration of timeout.
+// Devices are deduplicated by MACAddress (last-seen wins).
+// Returns the deduplicated slice, sorted by Identity.
+func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*Device, error) {
+	var ifaces []net.Interface
+
+	if ifaceName != "" {
+		iface, err := net.InterfaceByName(ifaceName)
+		if err != nil {
+			return nil, fmt.Errorf("mndp: interface %q not found: %w", ifaceName, err)
+		}
+		ifaces = []net.Interface{*iface}
+	} else {
+		all, err := net.Interfaces()
+		if err != nil {
+			return nil, fmt.Errorf("mndp: failed to list interfaces: %w", err)
+		}
+		for _, iface := range all {
+			if iface.Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			if iface.Flags&net.FlagPointToPoint != 0 {
+				continue
+			}
+			if iface.Flags&net.FlagUp == 0 {
+				continue
+			}
+			ifaces = append(ifaces, iface)
+		}
+	}
+
+	var mu sync.Mutex
+	devByMAC := make(map[string]*Device)
+
+	var wg sync.WaitGroup
+
+	for _, iface := range ifaces {
+		ipv4, err := firstIPv4(iface)
+		if err != nil {
+			slog.Debug("mndp: skipping interface (no IPv4)", "interface", iface.Name, "error", err)
+			continue
+		}
+
+		addr := ipv4 + ":5678"
+		conn, err := net.ListenPacket("udp4", addr)
+		if err != nil {
+			slog.Debug("mndp: failed to bind on interface", "interface", iface.Name, "addr", addr, "error", err)
+			continue
+		}
+
+		if err := SendProbe(conn); err != nil {
+			slog.Debug("mndp: probe send failed", "interface", iface.Name, "error", err)
+			_ = conn.Close()
+			continue
+		}
+
+		deadline := time.Now().Add(timeout)
+		if err := conn.SetDeadline(deadline); err != nil {
+			slog.Debug("mndp: failed to set deadline", "interface", iface.Name, "error", err)
+			_ = conn.Close()
+			continue
+		}
+
+		wg.Add(1)
+		go func(conn net.PacketConn, ifName string) {
+			defer wg.Done()
+			defer func() { _ = conn.Close() }()
+
+			buf := make([]byte, 4096)
+			for {
+				n, _, err := conn.ReadFrom(buf)
+				if err != nil {
+					// Timeout or other error; stop reading this interface
+					break
+				}
+
+				dev, err := ParsePacket(buf[:n])
+				if err != nil {
+					slog.Debug("mndp: parse error", "interface", ifName, "error", err)
+					continue
+				}
+				dev.InterfaceName = ifName
+
+				mu.Lock()
+				devByMAC[dev.MACAddress] = dev // last-seen wins
+				mu.Unlock()
+			}
+		}(conn, iface.Name)
+	}
+
+	wg.Wait()
+
+	return deduplicateDevices(devByMAC), nil
+}
+
+// SendProbe sends an MNDP discovery request packet on conn.
+// Exported for testability.
+//
+// Packet format:
+//
+//	[0x00 0x00]  msg-type = 0x0000 (request), LE
+//	[0x00 0x00]  sequence = 0, LE
+func SendProbe(conn net.PacketConn) error {
+	dst, err := net.ResolveUDPAddr("udp4", "255.255.255.255:5678")
+	if err != nil {
+		return fmt.Errorf("mndp: failed to resolve broadcast addr: %w", err)
+	}
+	probe := []byte{0x00, 0x00, 0x00, 0x00}
+	if _, err := conn.WriteTo(probe, dst); err != nil {
+		return fmt.Errorf("mndp: failed to send probe: %w", err)
+	}
+	return nil
+}
+
+// firstIPv4 returns the string representation of the first IPv4 unicast
+// address assigned to iface, or an error if none is found.
+func firstIPv4(iface net.Interface) (string, error) {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip := v.IP.To4()
+			if ip != nil {
+				return ip.String(), nil
+			}
+		case *net.IPAddr:
+			ip := v.IP.To4()
+			if ip != nil {
+				return ip.String(), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no IPv4 address found on interface %q", iface.Name)
+}
+
+// deduplicateDevices takes the last-seen-wins map, builds a slice, and sorts it by Identity.
+func deduplicateDevices(devByMAC map[string]*Device) []*Device {
+	devices := make([]*Device, 0, len(devByMAC))
+	for _, d := range devByMAC {
+		devices = append(devices, d)
+	}
+	slices.SortFunc(devices, func(a, b *Device) int {
+		return strings.Compare(a.Identity, b.Identity)
+	})
+	return devices
+}

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -2,6 +2,7 @@ package mndp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -92,12 +93,13 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 				n, _, err := conn.ReadFrom(buf)
 				if err != nil {
 					if ne, ok := err.(net.Error); ok && ne.Timeout() {
-						if time.Now().After(deadline) || time.Now().Equal(deadline) {
+						now := time.Now()
+						if !now.Before(deadline) {
 							break
 						}
 						continue
 					}
-					if ctx.Err() != nil || err == net.ErrClosed {
+					if errors.Is(err, net.ErrClosed) {
 						break
 					}
 					break

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -110,6 +110,7 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 					if errors.Is(err, net.ErrClosed) {
 						break
 					}
+					slog.Debug("mndp: read error", "interface", ifName, "error", err)
 					break
 				}
 

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -2,7 +2,6 @@ package mndp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -70,39 +69,37 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 		}
 
 		deadline := time.Now().Add(timeout)
-		if err := conn.SetDeadline(deadline); err != nil {
-			slog.Debug("mndp: failed to set deadline", "interface", iface.Name, "error", err)
-			_ = conn.Close()
-			continue
-		}
-
 		wg.Add(1)
 		go func(conn net.PacketConn, ifName string) {
 			defer wg.Done()
 			defer func() { _ = conn.Close() }()
 
-			done := make(chan struct{})
-			go func() {
-				select {
-				case <-ctx.Done():
-					_ = conn.Close()
-				case <-done:
-				}
-			}()
-			defer close(done)
-
 			buf := make([]byte, 4096)
 			for {
+				if ctx.Err() != nil {
+					break
+				}
+
+				readDeadline := time.Now().Add(250 * time.Millisecond)
+				if readDeadline.After(deadline) {
+					readDeadline = deadline
+				}
+				if err := conn.SetReadDeadline(readDeadline); err != nil {
+					slog.Debug("mndp: failed to set read deadline", "interface", ifName, "error", err)
+					break
+				}
+
 				n, _, err := conn.ReadFrom(buf)
 				if err != nil {
-					if ctx.Err() != nil {
+					if ne, ok := err.(net.Error); ok && ne.Timeout() {
+						if time.Now().After(deadline) || time.Now().Equal(deadline) {
+							break
+						}
+						continue
+					}
+					if ctx.Err() != nil || err == net.ErrClosed {
 						break
 					}
-					if errors.Is(err, net.ErrClosed) {
-						break
-					}
-
-					// Timeout or other error; stop reading this interface
 					break
 				}
 

--- a/common/mndp/listener_test.go
+++ b/common/mndp/listener_test.go
@@ -1,7 +1,9 @@
 package mndp
 
 import (
+	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -125,5 +127,15 @@ func TestDeduplicateDevices_SortedByIdentity(t *testing.T) {
 	if result[0].Identity != "apple" || result[1].Identity != "mango" || result[2].Identity != "zebra" {
 		t.Errorf("deduplicateDevices() not sorted: got %q, %q, %q",
 			result[0].Identity, result[1].Identity, result[2].Identity)
+	}
+}
+
+func TestListen_RejectsNonPositiveTimeout(t *testing.T) {
+	_, err := Listen(context.Background(), "", 0)
+	if err == nil {
+		t.Fatal("Listen() expected error for non-positive timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout must be greater than 0") {
+		t.Fatalf("Listen() error = %v, want timeout validation error", err)
 	}
 }

--- a/common/mndp/listener_test.go
+++ b/common/mndp/listener_test.go
@@ -1,0 +1,129 @@
+package mndp
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// mockPacketConn implements net.PacketConn and captures WriteTo calls.
+type mockPacketConn struct {
+	writtenData []byte
+	writtenAddr net.Addr
+}
+
+func (m *mockPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	m.writtenData = append([]byte(nil), p...)
+	m.writtenAddr = addr
+	return len(p), nil
+}
+
+func (m *mockPacketConn) ReadFrom(_ []byte) (int, net.Addr, error) {
+	return 0, nil, net.ErrClosed
+}
+
+func (m *mockPacketConn) Close() error {
+	return nil
+}
+
+func (m *mockPacketConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+}
+
+func (m *mockPacketConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (m *mockPacketConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (m *mockPacketConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+// Ensure mockPacketConn satisfies net.PacketConn at compile time.
+var _ net.PacketConn = (*mockPacketConn)(nil)
+
+func TestSendProbe_WritesCorrectPayload(t *testing.T) {
+	mock := &mockPacketConn{}
+
+	if err := SendProbe(mock); err != nil {
+		t.Fatalf("SendProbe() unexpected error = %v", err)
+	}
+
+	want := []byte{0x00, 0x00, 0x00, 0x00}
+	if len(mock.writtenData) != 4 {
+		t.Fatalf("SendProbe() wrote %d bytes, want 4", len(mock.writtenData))
+	}
+	for i, b := range want {
+		if mock.writtenData[i] != b {
+			t.Errorf("SendProbe() written[%d] = 0x%02x, want 0x%02x", i, mock.writtenData[i], b)
+		}
+	}
+}
+
+func TestSendProbe_SendsToBroadcast(t *testing.T) {
+	mock := &mockPacketConn{}
+
+	if err := SendProbe(mock); err != nil {
+		t.Fatalf("SendProbe() unexpected error = %v", err)
+	}
+
+	udpAddr, ok := mock.writtenAddr.(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("SendProbe() destination addr type = %T, want *net.UDPAddr", mock.writtenAddr)
+	}
+	if !udpAddr.IP.Equal(net.IPv4bcast) {
+		t.Errorf("SendProbe() destination IP = %v, want 255.255.255.255", udpAddr.IP)
+	}
+	if udpAddr.Port != 5678 {
+		t.Errorf("SendProbe() destination port = %d, want 5678", udpAddr.Port)
+	}
+}
+
+func TestDeduplicateDevices_LastSeenWins(t *testing.T) {
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+
+	pkt1 := buildTestPacket(mac, "first-identity", "", "", 0, "", "", nil, nil)
+	pkt2 := buildTestPacket(mac, "last-identity", "", "", 0, "", "", nil, nil)
+
+	devByMAC := make(map[string]*Device)
+
+	dev1, err := ParsePacket(pkt1)
+	if err != nil {
+		t.Fatalf("ParsePacket(pkt1) error = %v", err)
+	}
+	devByMAC[dev1.MACAddress] = dev1
+
+	dev2, err := ParsePacket(pkt2)
+	if err != nil {
+		t.Fatalf("ParsePacket(pkt2) error = %v", err)
+	}
+	devByMAC[dev2.MACAddress] = dev2 // overwrites dev1 (last-seen wins)
+
+	result := deduplicateDevices(devByMAC)
+	if len(result) != 1 {
+		t.Fatalf("deduplicateDevices() returned %d devices, want 1", len(result))
+	}
+	if result[0].Identity != "last-identity" {
+		t.Errorf("deduplicateDevices() identity = %q, want %q", result[0].Identity, "last-identity")
+	}
+}
+
+func TestDeduplicateDevices_SortedByIdentity(t *testing.T) {
+	devByMAC := map[string]*Device{
+		"aa:bb:cc:dd:ee:01": {MACAddress: "aa:bb:cc:dd:ee:01", Identity: "zebra"},
+		"aa:bb:cc:dd:ee:02": {MACAddress: "aa:bb:cc:dd:ee:02", Identity: "apple"},
+		"aa:bb:cc:dd:ee:03": {MACAddress: "aa:bb:cc:dd:ee:03", Identity: "mango"},
+	}
+
+	result := deduplicateDevices(devByMAC)
+	if len(result) != 3 {
+		t.Fatalf("deduplicateDevices() returned %d devices, want 3", len(result))
+	}
+	if result[0].Identity != "apple" || result[1].Identity != "mango" || result[2].Identity != "zebra" {
+		t.Errorf("deduplicateDevices() not sorted: got %q, %q, %q",
+			result[0].Identity, result[1].Identity, result[2].Identity)
+	}
+}

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -1,0 +1,106 @@
+package mndp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+const (
+	tlvMAC        = 1
+	tlvIdentity   = 5
+	tlvVersion    = 7
+	tlvPlatform   = 8
+	tlvUptime     = 10
+	tlvSoftwareID = 11
+	tlvBoard      = 12
+	tlvIPv4       = 15
+
+	msgTypeRequest  = 0x0000
+	msgTypeResponse = 0x0001
+)
+
+// ParsePacket parses an MNDP response packet and returns the discovered Device.
+//
+// Wire format:
+//
+//	[2B msg-type LE][2B sequence LE] [TLV…]
+//	TLV: [2B type LE][2B length LE][length bytes value]
+//
+// Returns an error for:
+//   - Packets shorter than 4 bytes
+//   - msg-type 0x0000 (request) or unknown types
+//   - Truncated TLV values
+//   - Missing MAC address TLV
+//   - Missing Identity TLV
+func ParsePacket(data []byte) (*Device, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("mndp: packet too short (%d bytes)", len(data))
+	}
+
+	msgType := binary.LittleEndian.Uint16(data[0:2])
+
+	switch msgType {
+	case msgTypeRequest:
+		return nil, fmt.Errorf("mndp: packet is a request (msg-type 0x0000), not a response")
+	case msgTypeResponse:
+		// OK — continue parsing
+	default:
+		return nil, fmt.Errorf("mndp: unknown msg-type 0x%04x", msgType)
+	}
+
+	dev := &Device{}
+	offset := 4
+
+	for offset < len(data) {
+		if offset+4 > len(data) {
+			return nil, fmt.Errorf("mndp: truncated TLV header at offset %d", offset)
+		}
+		tlvType := binary.LittleEndian.Uint16(data[offset : offset+2])
+		tlvLen := int(binary.LittleEndian.Uint16(data[offset+2 : offset+4]))
+		offset += 4
+
+		if offset+tlvLen > len(data) {
+			return nil, fmt.Errorf("mndp: truncated TLV value: type=%d declared length=%d available=%d",
+				tlvType, tlvLen, len(data)-offset)
+		}
+
+		value := data[offset : offset+tlvLen]
+		offset += tlvLen
+
+		switch tlvType {
+		case tlvMAC:
+			if tlvLen == 6 {
+				dev.MACAddress = net.HardwareAddr(value).String()
+			}
+		case tlvIdentity:
+			dev.Identity = string(value)
+		case tlvVersion:
+			dev.Version = string(value)
+		case tlvPlatform:
+			dev.Platform = string(value)
+		case tlvUptime:
+			if tlvLen == 4 {
+				dev.Uptime = binary.LittleEndian.Uint32(value)
+			}
+		case tlvSoftwareID:
+			dev.SoftwareID = string(value)
+		case tlvBoard:
+			dev.Board = string(value)
+		case tlvIPv4:
+			if tlvLen == 4 {
+				dev.IPv4Address = net.IP(value).String()
+			}
+			// tlvLen == 16 is IPv6 — silently skipped (not yet supported)
+		}
+	}
+
+	if dev.MACAddress == "" {
+		return nil, fmt.Errorf("mndp: missing required MAC address TLV")
+	}
+	if dev.Identity == "" {
+		return nil, fmt.Errorf("mndp: missing required Identity TLV")
+	}
+
+	return dev, nil
+}

--- a/common/mndp/parser_test.go
+++ b/common/mndp/parser_test.go
@@ -1,0 +1,225 @@
+package mndp
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildTestPacket constructs a minimal valid MNDP response packet for testing.
+// mac must be 6 bytes; identity must be non-empty.
+func buildTestPacket(mac []byte, identity, version, platform string, uptime uint32, softwareID, board string, ipv4 []byte, ipv6 []byte) []byte {
+	pkt := []byte{
+		0x01, 0x00, // msg-type = 0x0001 (response), LE
+		0x00, 0x00, // sequence = 0
+	}
+
+	appendTLV := func(tlvType uint16, value []byte) {
+		hdr := make([]byte, 4)
+		binary.LittleEndian.PutUint16(hdr[0:2], tlvType)
+		binary.LittleEndian.PutUint16(hdr[2:4], uint16(len(value)))
+		pkt = append(pkt, hdr...)
+		pkt = append(pkt, value...)
+	}
+
+	if len(mac) == 6 {
+		appendTLV(tlvMAC, mac)
+	}
+	if identity != "" {
+		appendTLV(tlvIdentity, []byte(identity))
+	}
+	if version != "" {
+		appendTLV(tlvVersion, []byte(version))
+	}
+	if platform != "" {
+		appendTLV(tlvPlatform, []byte(platform))
+	}
+	if uptime != 0 {
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, uptime)
+		appendTLV(tlvUptime, b)
+	}
+	if softwareID != "" {
+		appendTLV(tlvSoftwareID, []byte(softwareID))
+	}
+	if board != "" {
+		appendTLV(tlvBoard, []byte(board))
+	}
+	if len(ipv4) == 4 {
+		appendTLV(tlvIPv4, ipv4)
+	}
+	if len(ipv6) == 16 {
+		// MNDP uses TLV type 15 for both IPv4 and IPv6, distinguished by length:
+		// 4 bytes = IPv4, 16 bytes = IPv6. The parser skips IPv6 entries silently.
+		appendTLV(tlvIPv4, ipv6)
+	}
+
+	return pkt
+}
+
+func TestParsePacket_FullValidResponse(t *testing.T) {
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	ipv4 := []byte{192, 168, 1, 1}
+	pkt := buildTestPacket(mac, "router.home", "7.16.2", "MikroTik", 3600, "some-id", "RB4011", ipv4, nil)
+
+	dev, err := ParsePacket(pkt)
+	if err != nil {
+		t.Fatalf("ParsePacket() unexpected error = %v", err)
+	}
+	if dev.MACAddress != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("MACAddress = %q, want %q", dev.MACAddress, "aa:bb:cc:dd:ee:ff")
+	}
+	if dev.Identity != "router.home" {
+		t.Errorf("Identity = %q, want %q", dev.Identity, "router.home")
+	}
+	if dev.Version != "7.16.2" {
+		t.Errorf("Version = %q, want %q", dev.Version, "7.16.2")
+	}
+	if dev.Platform != "MikroTik" {
+		t.Errorf("Platform = %q, want %q", dev.Platform, "MikroTik")
+	}
+	if dev.Uptime != 3600 {
+		t.Errorf("Uptime = %d, want 3600", dev.Uptime)
+	}
+	if dev.SoftwareID != "some-id" {
+		t.Errorf("SoftwareID = %q, want %q", dev.SoftwareID, "some-id")
+	}
+	if dev.Board != "RB4011" {
+		t.Errorf("Board = %q, want %q", dev.Board, "RB4011")
+	}
+	if dev.IPv4Address != "192.168.1.1" {
+		t.Errorf("IPv4Address = %q, want %q", dev.IPv4Address, "192.168.1.1")
+	}
+}
+
+func TestParsePacket_IPv6OnlyAddress(t *testing.T) {
+	mac := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	ipv6 := make([]byte, 16) // all-zeros IPv6 address
+	ipv6[0] = 0xFE
+	ipv6[1] = 0x80
+	pkt := buildTestPacket(mac, "router.home", "", "", 0, "", "", nil, ipv6)
+
+	dev, err := ParsePacket(pkt)
+	if err != nil {
+		t.Fatalf("ParsePacket() unexpected error = %v", err)
+	}
+	if dev.IPv4Address != "" {
+		t.Errorf("IPv4Address = %q, want empty (IPv6 should be skipped)", dev.IPv4Address)
+	}
+}
+
+func TestParsePacket_BothIPv4AndIPv6(t *testing.T) {
+	mac := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	ipv4 := []byte{10, 0, 0, 1}
+	ipv6 := make([]byte, 16)
+	ipv6[0] = 0xFE
+	ipv6[1] = 0x80
+
+	// Manually construct a packet with both IPv4 and IPv6 TLVs
+	pkt := []byte{
+		0x01, 0x00, // msg-type = response
+		0x00, 0x00, // sequence
+	}
+	appendTLV := func(tlvType uint16, value []byte) {
+		hdr := make([]byte, 4)
+		binary.LittleEndian.PutUint16(hdr[0:2], tlvType)
+		binary.LittleEndian.PutUint16(hdr[2:4], uint16(len(value)))
+		pkt = append(pkt, hdr...)
+		pkt = append(pkt, value...)
+	}
+	appendTLV(tlvMAC, mac)
+	appendTLV(tlvIdentity, []byte("router.home"))
+	// In MNDP, TLV type 15 (tlvIPv4) is used for both IPv4 and IPv6 addresses.
+	// The length field distinguishes them: 4 bytes = IPv4, 16 bytes = IPv6.
+	// The parser skips IPv6 entries silently.
+	appendTLV(tlvIPv4, ipv4) // IPv4: length 4 → should be stored
+	appendTLV(tlvIPv4, ipv6) // IPv6: length 16 → should be skipped
+
+	dev, err := ParsePacket(pkt)
+	if err != nil {
+		t.Fatalf("ParsePacket() unexpected error = %v", err)
+	}
+	if dev.IPv4Address != "10.0.0.1" {
+		t.Errorf("IPv4Address = %q, want %q", dev.IPv4Address, "10.0.0.1")
+	}
+}
+
+func TestParsePacket_TruncatedTLV(t *testing.T) {
+	pkt := []byte{
+		0x01, 0x00, // msg-type = response
+		0x00, 0x00, // sequence
+		0x01, 0x00, // TLV type = 1 (MAC)
+		0x06, 0x00, // TLV length = 6
+		// Only 2 bytes of value instead of 6 — truncated
+		0xAA, 0xBB,
+	}
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for truncated TLV, got nil")
+	}
+}
+
+func TestParsePacket_MissingMAC(t *testing.T) {
+	// Packet with identity but no MAC
+	pkt := []byte{
+		0x01, 0x00, // msg-type = response
+		0x00, 0x00, // sequence
+		0x05, 0x00, // TLV type = 5 (Identity)
+		0x06, 0x00, // TLV length = 6
+		'r', 'o', 'u', 't', 'e', 'r', // "router"
+	}
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for missing MAC, got nil")
+	}
+}
+
+func TestParsePacket_MissingIdentity(t *testing.T) {
+	// Packet with MAC but no identity
+	pkt := []byte{
+		0x01, 0x00, // msg-type = response
+		0x00, 0x00, // sequence
+		0x01, 0x00, // TLV type = 1 (MAC)
+		0x06, 0x00, // TLV length = 6
+		0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+	}
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for missing Identity, got nil")
+	}
+}
+
+func TestParsePacket_TooShort(t *testing.T) {
+	pkt := []byte{0x01, 0x00} // only 2 bytes
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for short packet, got nil")
+	}
+}
+
+func TestParsePacket_RequestPacket(t *testing.T) {
+	pkt := []byte{
+		0x00, 0x00, // msg-type = 0x0000 (request)
+		0x00, 0x00, // sequence
+	}
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for request packet, got nil")
+	}
+}
+
+func TestParsePacket_UnknownMsgType(t *testing.T) {
+	pkt := []byte{
+		0xFF, 0xFF, // msg-type = 0xFFFF (unknown)
+		0x00, 0x00, // sequence
+	}
+
+	_, err := ParsePacket(pkt)
+	if err == nil {
+		t.Fatal("ParsePacket() expected error for unknown msg-type, got nil")
+	}
+}

--- a/common/mndp/types.go
+++ b/common/mndp/types.go
@@ -1,0 +1,14 @@
+package mndp
+
+// Device represents a MikroTik device discovered via MNDP.
+type Device struct {
+	MACAddress    string // TLV type 1  — canonical deduplication key (hex string, e.g. "AA:BB:CC:DD:EE:FF")
+	Identity      string // TLV type 5  — matches LLDP neighbor identity
+	Version       string // TLV type 7
+	Platform      string // TLV type 8  ("MikroTik")
+	Uptime        uint32 // TLV type 10 — seconds (4-byte LE)
+	SoftwareID    string // TLV type 11
+	Board         string // TLV type 12
+	IPv4Address   string // TLV type 15, length==4 only; IPv6 (length==16) is silently skipped
+	InterfaceName string // local NIC on which the UDP response arrived
+}

--- a/common/mndp/types.go
+++ b/common/mndp/types.go
@@ -2,7 +2,7 @@ package mndp
 
 // Device represents a MikroTik device discovered via MNDP.
 type Device struct {
-	MACAddress    string // TLV type 1  — canonical deduplication key (hex string, e.g. "AA:BB:CC:DD:EE:FF")
+	MACAddress    string // TLV type 1  — canonical deduplication key (lower-case hex string, e.g. "aa:bb:cc:dd:ee:ff")
 	Identity      string // TLV type 5  — matches LLDP neighbor identity
 	Version       string // TLV type 7
 	Platform      string // TLV type 8  ("MikroTik")

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Name:        "host",
 				Aliases:     []string{"H"},
 				Value:       "",
-				Usage:       "Comma-separated list of MikroTik hosts. Mutually exclusive with --mndp",
+				Usage:       "Comma-separated list of MikroTik hosts. Mutually exclusive with --mndp. If omitted and --mndp is not set, routers are auto-discovered from router*.rsc files",
 				Destination: hosts,
 			},
 			&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/urfave/cli/v3"
 	"jb.favre/mikrotik-fleet-autopilot/cmd/discover"
@@ -45,7 +46,7 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Name:        "host",
 				Aliases:     []string{"H"},
 				Value:       "",
-				Usage:       "MikroTik router hostname or IP address (comma-separated for multiple routers). If not provided, will auto-discover from router*.rsc files in current directory",
+				Usage:       "Comma-separated list of MikroTik hosts. Mutually exclusive with --mndp",
 				Destination: hosts,
 			},
 			&cli.StringFlag{
@@ -98,6 +99,25 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				Usage:       "Force buffered host progress output (deterministic final flush). By default, live display is preferred on TTY unless --debug is enabled",
 				Destination: &globalConfig.BufferedOutput,
 			},
+			&cli.StringFlag{
+				Name:        "interface",
+				Aliases:     []string{"i"},
+				Category:    "discovery",
+				Usage:       "Network interface to use for MNDP discovery (default: all non-loopback interfaces). Only used with --mndp",
+				Destination: &globalConfig.Interface,
+			},
+			&cli.BoolFlag{
+				Name:        "mndp",
+				Category:    "discovery",
+				Usage:       "Dynamically discover MikroTik devices via MNDP. Mutually exclusive with --host",
+				Destination: &globalConfig.UseMNDP,
+			},
+			&cli.StringFlag{
+				Name:     "mndp-timeout",
+				Category: "discovery",
+				Value:    "15s",
+				Usage:    "How long to listen for MNDP responses (e.g. 15s, 1m). Only used with --mndp",
+			},
 		},
 		Commands: append(append(append(export.Command, updates.Command...), enroll.Command...), discover.Command...),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
@@ -117,15 +137,29 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			globalConfig.EffectiveMaxConcurrent = effectiveMaxConcurrent
 			globalConfig.PreferLiveMode = !globalConfig.BufferedOutput
 
+			if raw := cmd.String("mndp-timeout"); raw != "" {
+				d, err := time.ParseDuration(raw)
+				if err != nil {
+					return ctx, fmt.Errorf("invalid --mndp-timeout value %q: %w", raw, err)
+				}
+				globalConfig.MNDPTimeout = d
+			}
+
 			// Check if a subcommand was provided
 			// If not, the help will be shown automatically by urfave/cli
 			if cmd.Args().Len() > 0 {
 				slog.Debug("command line arguments", "args", cmd.Args())
+
+				// Mutual exclusivity guard
+				if *hosts != "" && globalConfig.UseMNDP {
+					return ctx, fmt.Errorf("--host and --mndp are mutually exclusive: use --mndp for dynamic discovery or --host to target specific devices")
+				}
+
 				// Setup hosts
 				if *hosts != "" {
 					// Split comma-separated hosts
 					globalConfig.Hosts = core.ParseHosts(*hosts)
-				} else {
+				} else if !globalConfig.UseMNDP {
 					// Auto-discover routers
 					routers, err := core.DiscoverHosts()
 					if err != nil {
@@ -134,8 +168,9 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 					globalConfig.Hosts = routers
 					slog.Info("auto-discovered routers", "count", len(routers), "routers", routers)
 				}
+				// When --mndp is set, Hosts stays empty here; discover subcommand populates it.
 
-				if len(globalConfig.Hosts) == 0 {
+				if len(globalConfig.Hosts) == 0 && !globalConfig.UseMNDP {
 					slog.Error("no routers specified or discovered")
 					return ctx, fmt.Errorf("no routers specified or discovered")
 				}

--- a/main.go
+++ b/main.go
@@ -152,6 +152,11 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 			// If not, the help will be shown automatically by urfave/cli
 			if cmd.Args().Len() > 0 {
 				slog.Debug("command line arguments", "args", cmd.Args())
+				subcommand := cmd.Args().Get(0)
+
+				if globalConfig.UseMNDP && subcommand != "discover" {
+					return ctx, fmt.Errorf("--mndp is only supported with the discover subcommand")
+				}
 
 				// Mutual exclusivity guard
 				if *hosts != "" && globalConfig.UseMNDP {

--- a/main.go
+++ b/main.go
@@ -142,6 +142,9 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 				if err != nil {
 					return ctx, fmt.Errorf("invalid --mndp-timeout value %q: %w", raw, err)
 				}
+				if d <= 0 {
+					return ctx, fmt.Errorf("invalid --mndp-timeout value %q: must be greater than 0", raw)
+				}
 				globalConfig.MNDPTimeout = d
 			}
 

--- a/main.go
+++ b/main.go
@@ -146,6 +146,8 @@ func buildCommand(globalConfig *core.Config, hosts, sshPassword, sshPassphrase *
 					return ctx, fmt.Errorf("invalid --mndp-timeout value %q: must be greater than 0", raw)
 				}
 				globalConfig.MNDPTimeout = d
+			} else {
+				return ctx, fmt.Errorf("invalid --mndp-timeout value %q: cannot be empty", raw)
 			}
 
 			// Check if a subcommand was provided

--- a/main_test.go
+++ b/main_test.go
@@ -675,19 +675,18 @@ func TestMNDPFlagAloneDoesNotError(t *testing.T) {
 
 	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
 
-	// Use a pre-cancelled context so the Before hook fires but the action exits immediately.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cancel()
-	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--mndp", "discover"})
+	// Use --help to stop after CLI parsing/validation so the test does not execute
+	// the real discover action or touch network interfaces.
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--mndp", "--help"})
 
-	// The context cancel should cause a context.Canceled error (or MNDP fires and fails),
-	// but NOT a mutual exclusivity / "no routers" error.
-	if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("--mndp alone must not trigger mutual exclusivity error, got: %v", err)
-	}
-	if err != nil && strings.Contains(err.Error(), "no routers specified") {
-		t.Errorf("--mndp alone must not trigger 'no routers' error, got: %v", err)
+	if err != nil {
+		if strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("--mndp alone must not trigger mutual exclusivity error, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "no routers specified") {
+			t.Errorf("--mndp alone must not trigger 'no routers' error, got: %v", err)
+		}
+		t.Errorf("cmd.Run() unexpected error = %v", err)
 	}
 	if !globalConfig.UseMNDP {
 		t.Error("UseMNDP should be true when --mndp flag is set")

--- a/main_test.go
+++ b/main_test.go
@@ -693,6 +693,20 @@ func TestMNDPFlagAloneDoesNotError(t *testing.T) {
 	}
 }
 
+func TestMNDPFlagRejectedForNonDiscoverSubcommands(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--mndp", "updates"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected error for --mndp on non-discover subcommand, got nil")
+	}
+	if !strings.Contains(err.Error(), "only supported with the discover subcommand") {
+		t.Errorf("unexpected error for --mndp with updates: %v", err)
+	}
+}
+
 func TestMNDPTimeoutFlagParsed(t *testing.T) {
 	var globalConfig core.Config
 	var hosts, sshPassword, sshPassphrase string
@@ -722,5 +736,19 @@ func TestMNDPTimeoutFlagInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid --mndp-timeout") {
 		t.Errorf("expected 'invalid --mndp-timeout' error, got: %v", err)
+	}
+}
+
+func TestMNDPTimeoutFlagNonPositive(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--mndp-timeout", "0s", "updates"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected error for non-positive --mndp-timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be greater than 0") {
+		t.Errorf("expected non-positive timeout error, got: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"jb.favre/mikrotik-fleet-autopilot/common/core"
 	"jb.favre/mikrotik-fleet-autopilot/common/ssh"
@@ -58,6 +59,9 @@ func TestBuildCommandFlags(t *testing.T) {
 		"max-concurrent-hosts": false,
 		"buffered-output":      false,
 		"skip-hostkey-check":   false,
+		"interface":            false,
+		"mndp":                 false,
+		"mndp-timeout":         false,
 	}
 
 	// Check all expected flags exist
@@ -77,8 +81,8 @@ func TestBuildCommandFlags(t *testing.T) {
 	}
 
 	// Test that we have the right number of flags
-	if len(cmd.Flags) != 8 {
-		t.Errorf("Expected 8 flags, got %d", len(cmd.Flags))
+	if len(cmd.Flags) != 11 {
+		t.Errorf("Expected 11 flags, got %d", len(cmd.Flags))
 	}
 }
 
@@ -648,5 +652,76 @@ func TestBuildCommandDisplayModeFlagRemoved(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "flag provided but not defined") {
 		t.Errorf("unexpected error for removed flag: %v", err)
+	}
+}
+
+func TestMNDPAndHostMutualExclusivity(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--mndp", "discover"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected mutual exclusivity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' error, got: %v", err)
+	}
+}
+
+func TestMNDPFlagAloneDoesNotError(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	// Use a pre-cancelled context so the Before hook fires but the action exits immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancel()
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--mndp", "discover"})
+
+	// The context cancel should cause a context.Canceled error (or MNDP fires and fails),
+	// but NOT a mutual exclusivity / "no routers" error.
+	if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("--mndp alone must not trigger mutual exclusivity error, got: %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "no routers specified") {
+		t.Errorf("--mndp alone must not trigger 'no routers' error, got: %v", err)
+	}
+	if !globalConfig.UseMNDP {
+		t.Error("UseMNDP should be true when --mndp flag is set")
+	}
+}
+
+func TestMNDPTimeoutFlagParsed(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancel()
+	err := cmd.Run(ctx, []string{"mikrotik-fleet-autopilot", "--host", "router1", "--mndp-timeout", "30s", "updates"})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("cmd.Run() unexpected error = %v", err)
+	}
+	if globalConfig.MNDPTimeout != 30*time.Second {
+		t.Errorf("MNDPTimeout = %v, want 30s", globalConfig.MNDPTimeout)
+	}
+}
+
+func TestMNDPTimeoutFlagInvalid(t *testing.T) {
+	var globalConfig core.Config
+	var hosts, sshPassword, sshPassphrase string
+
+	cmd := buildCommand(&globalConfig, &hosts, &sshPassword, &sshPassphrase)
+	err := cmd.Run(context.Background(), []string{"mikrotik-fleet-autopilot", "--host", "router1", "--mndp-timeout", "bad", "updates"})
+	if err == nil {
+		t.Fatal("cmd.Run() expected parse error for invalid --mndp-timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --mndp-timeout") {
+		t.Errorf("expected 'invalid --mndp-timeout' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Adds opt-in MNDP (MikroTik Neighbor Discovery Protocol) support to `discover` so it can dynamically seed SSH+LLDP topology probing without relying on `router*.rsc` file scanning or manual `--host` flags.

## New package: `common/mndp`

- **`parser.go`**: TLV wire-format parser (`[2B type LE][2B len LE][value]`). Validates msg-type (response `0x0001` only), handles all 8 TLV types. Type 15 encodes both IPv4 (len=4, stored) and IPv6 (len=16, silently skipped). Errors on truncation, missing MAC, missing Identity.
- **`listener.go`**: `Listen(ctx, ifaceName, timeout)` — binds a UDP socket per eligible interface, sends a 4-byte MNDP probe to `255.255.255.255:5678`, collects/parses responses concurrently, deduplicates by MAC (last-seen wins), returns sorted-by-Identity slice. `SendProbe` is exported for testability.

## Global flags (all subcommands)

| Flag | Default | Notes |
|---|---|---|
| `--mndp` | false | Opt-in MNDP discovery; mutually exclusive with `--host` |
| `--interface` / `-i` | (all) | Restrict MNDP to a single NIC; only meaningful with `--mndp` |
| `--mndp-timeout` | `15s` | Collection window; parsed as `time.Duration` in `Before` hook |

`--host` + `--mndp` together returns an error early in the `Before` hook. With `--mndp`, the `Hosts` slice stays empty until `discover` populates it from MNDP results; the existing file-based fallback is skipped.

## `discover` command changes

- Injectable `listenMNDP` package-level var (same pattern as `createSSHConnection`) for test isolation.
- `topology` extended with `mndpByIP` and `ipToIdentity` maps.
- When `--mndp` is set, `runDiscoverForHosts` calls MNDP first, maps IPv4 → Identity, then runs the existing LLDP SSH loop against discovered IPs.
- MNDP errors are non-fatal (warn + fall through to "no hosts" error if the list is empty).

## Output enrichment

- `topologyNode` gains `sshReachable *bool` (`nil` = no attempt, `&true` = ok, `&false` = failed).
- `buildTopologyGraph` now accepts `*topology` directly, resolves canonical node names via `ipToIdentity` (MNDP identity preferred over bare IP), and marks reachability from `topo.results`/`topo.errors`.
- SSH-unreachable nodes render with a `❓` prefix in both root and child positions.
- Summary section gains an `Unreachable devices` line when any node has `sshReachable = false`.

```
[router-core]
  ├─ [router-leaf1]
  │   via ether1 ↔ sfp1
  │
  └─ [❓ 192.168.88.5]   ← MNDP-visible, SSH failed

───────────────────────────────────────────────────────────────
Summary:
  Total devices        : 3
  Unreachable devices  : 1  (MNDP-visible, SSH failed)
```
