### PR TITLE
fix(cmd/mndp) Fix broken MNDP feature

### DIFF
--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -64,7 +64,7 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 			}
 			slog.Debug("mndp: failed to bind on interface", "interface", iface.Name, "addr", addr, "error", err)
 			continue
-		}else {
+		} else {
 			slog.Debug("mndp: successfull binding to interface", "interface", iface.Name, "addr", addr)
 		}
 

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -64,6 +64,8 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 			}
 			slog.Debug("mndp: failed to bind on interface", "interface", iface.Name, "addr", addr, "error", err)
 			continue
+		}else {
+			slog.Debug("mndp: successfull binding to interface", "interface", iface.Name, "addr", addr)
 		}
 
 		if err := SendProbe(conn); err != nil {

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -56,16 +56,16 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 	var wg sync.WaitGroup
 
 	for _, iface := range ifaces {
-		ipv4, err := firstIPv4(iface)
-		if err != nil {
-			if ifaceName != "" {
-				return nil, fmt.Errorf("mndp: interface %q has no usable IPv4 address: %w", iface.Name, err)
-			}
-			slog.Debug("mndp: skipping interface (no IPv4)", "interface", iface.Name, "error", err)
-			continue
-		}
+		//ipv4, err := firstIPv4(iface)
+		//if err != nil {
+		//	if ifaceName != "" {
+		//		return nil, fmt.Errorf("mndp: interface %q has no usable IPv4 address: %w", iface.Name, err)
+		//	}
+		//	slog.Debug("mndp: skipping interface (no IPv4)", "interface", iface.Name, "error", err)
+		//	continue
+		//}
 
-		addr := ipv4 + ":5678"
+		addr := "0.0.0.0:5678"
 		conn, err := net.ListenPacket("udp4", addr)
 		if err != nil {
 			if ifaceName != "" {
@@ -136,7 +136,10 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 				dev.InterfaceName = ifName
 
 				mu.Lock()
-				devByMAC[dev.MACAddress] = dev // last-seen wins
+				existing, seen := devByMAC[dev.MACAddress]
+				if !seen || dev.IPv4Address != "" || existing.IPv4Address == "" {
+					devByMAC[dev.MACAddress] = dev
+				}
 				mu.Unlock()
 			}
 		}(conn, iface.Name)

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -16,7 +16,7 @@ const listenReadPollInterval = 250 * time.Millisecond
 
 // Listen sends an MNDP probe on ifaceName (or all eligible interfaces when empty)
 // and collects responses for the duration of timeout.
-// Devices are deduplicated by MACAddress (last-seen wins).
+// Devices are deduplicated by MACAddress (IPv4 wins over empty IP address, newer IPv4 wins).
 // Returns the deduplicated slice, sorted by Identity.
 func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*Device, error) {
 	if timeout <= 0 {

--- a/common/mndp/listener.go
+++ b/common/mndp/listener.go
@@ -56,15 +56,6 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 	var wg sync.WaitGroup
 
 	for _, iface := range ifaces {
-		//ipv4, err := firstIPv4(iface)
-		//if err != nil {
-		//	if ifaceName != "" {
-		//		return nil, fmt.Errorf("mndp: interface %q has no usable IPv4 address: %w", iface.Name, err)
-		//	}
-		//	slog.Debug("mndp: skipping interface (no IPv4)", "interface", iface.Name, "error", err)
-		//	continue
-		//}
-
 		addr := "0.0.0.0:5678"
 		conn, err := net.ListenPacket("udp4", addr)
 		if err != nil {
@@ -137,7 +128,7 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 
 				mu.Lock()
 				existing, seen := devByMAC[dev.MACAddress]
-				if !seen || dev.IPv4Address != "" || existing.IPv4Address == "" {
+				if shouldReplaceDevice(seen, existing, dev) {
 					devByMAC[dev.MACAddress] = dev
 				}
 				mu.Unlock()
@@ -148,6 +139,23 @@ func Listen(ctx context.Context, ifaceName string, timeout time.Duration) ([]*De
 	wg.Wait()
 
 	return deduplicateDevices(devByMAC), nil
+}
+
+func shouldReplaceDevice(seen bool, existing, candidate *Device) bool {
+	if !seen {
+		return true
+	}
+	existingHasIPv4 := existing.IPv4Address != ""
+	candidateHasIPv4 := candidate.IPv4Address != ""
+
+	// Prefer the record that carries an IPv4 address; if both (or neither) have IPv4, prefer the newer record.
+	if !existingHasIPv4 && candidateHasIPv4 {
+		return true
+	}
+	if existingHasIPv4 && !candidateHasIPv4 {
+		return false
+	}
+	return true
 }
 
 // SendProbe sends an MNDP discovery request packet on conn.
@@ -167,30 +175,6 @@ func SendProbe(conn net.PacketConn) error {
 		return fmt.Errorf("mndp: failed to send probe: %w", err)
 	}
 	return nil
-}
-
-// firstIPv4 returns the string representation of the first IPv4 unicast
-// address assigned to iface, or an error if none is found.
-func firstIPv4(iface net.Interface) (string, error) {
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return "", err
-	}
-	for _, addr := range addrs {
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip := v.IP.To4()
-			if ip != nil {
-				return ip.String(), nil
-			}
-		case *net.IPAddr:
-			ip := v.IP.To4()
-			if ip != nil {
-				return ip.String(), nil
-			}
-		}
-	}
-	return "", fmt.Errorf("no IPv4 address found on interface %q", iface.Name)
 }
 
 // deduplicateDevices takes the last-seen-wins map, builds a slice, and sorts it by Identity.

--- a/common/mndp/listener_test.go
+++ b/common/mndp/listener_test.go
@@ -130,6 +130,64 @@ func TestDeduplicateDevices_SortedByIdentity(t *testing.T) {
 	}
 }
 
+func TestShouldReplaceDevice(t *testing.T) {
+	withIPv4 := &Device{IPv4Address: "192.168.1.10"}
+	withoutIPv4 := &Device{}
+
+	tests := []struct {
+		name      string
+		seen      bool
+		existing  *Device
+		candidate *Device
+		want      bool
+	}{
+		{
+			name:      "unseen device is always accepted",
+			seen:      false,
+			existing:  nil,
+			candidate: withoutIPv4,
+			want:      true,
+		},
+		{
+			name:      "candidate with IPv4 replaces existing without IPv4",
+			seen:      true,
+			existing:  withoutIPv4,
+			candidate: withIPv4,
+			want:      true,
+		},
+		{
+			name:      "candidate without IPv4 does not replace existing with IPv4",
+			seen:      true,
+			existing:  withIPv4,
+			candidate: withoutIPv4,
+			want:      false,
+		},
+		{
+			name:      "candidate with IPv4 replaces existing with IPv4 as newer record",
+			seen:      true,
+			existing:  withIPv4,
+			candidate: withIPv4,
+			want:      true,
+		},
+		{
+			name:      "candidate without IPv4 replaces existing without IPv4 as newer record",
+			seen:      true,
+			existing:  withoutIPv4,
+			candidate: withoutIPv4,
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldReplaceDevice(tt.seen, tt.existing, tt.candidate)
+			if got != tt.want {
+				t.Fatalf("shouldReplaceDevice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestListen_RejectsNonPositiveTimeout(t *testing.T) {
 	_, err := Listen(context.Background(), "", 0)
 	if err == nil {

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -3,29 +3,31 @@ package mndp
 import (
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"net"
 )
 
 const (
-	tlvMAC        = 1
-	tlvIdentity   = 5
-	tlvVersion    = 7
-	tlvPlatform   = 8
-	tlvUptime     = 10
-	tlvSoftwareID = 11
-	tlvBoard      = 12
-	tlvIPv4       = 15
-
-	msgTypeRequest  = 0x0000
-	msgTypeResponse = 0x0001
+	tlvMAC                 = 1
+	tlvIdentity            = 5
+	tlvVersion             = 7
+	tlvPlatform            = 8
+	tlvUptime              = 10
+	tlvSoftwareID          = 11
+	tlvBoard               = 12
+	tlvUnpack              = 14
+	tlvIPv6                = 15
+	tlvSourceInterfaceName = 16
+	tlvIPv4                = 17
+	tlvUnknown18           = 18 // observed in the wild; purpose unknown
 )
 
 // ParsePacket parses an MNDP response packet and returns the discovered Device.
 //
 // Wire format:
 //
-//	[2B msg-type LE][2B sequence LE] [TLV…]
-//	TLV: [2B type LE][2B length LE][length bytes value]
+//		// Header: [1B seq_lo] [1B msg-type] [1B seq_hi or reserved] [1B counter/reserved]
+//	      [TLV…][2B type LE][2B length LE][length bytes value]
 //
 // Returns an error for:
 //   - Packets shorter than 4 bytes
@@ -38,17 +40,6 @@ func ParsePacket(data []byte) (*Device, error) {
 		return nil, fmt.Errorf("mndp: packet too short (%d bytes)", len(data))
 	}
 
-	msgType := binary.LittleEndian.Uint16(data[0:2])
-
-	switch msgType {
-	case msgTypeRequest:
-		return nil, fmt.Errorf("mndp: packet is a request (msg-type 0x0000), not a response")
-	case msgTypeResponse:
-		// OK — continue parsing
-	default:
-		return nil, fmt.Errorf("mndp: unknown msg-type 0x%04x", msgType)
-	}
-
 	dev := &Device{}
 	offset := 4
 
@@ -56,8 +47,8 @@ func ParsePacket(data []byte) (*Device, error) {
 		if offset+4 > len(data) {
 			return nil, fmt.Errorf("mndp: truncated TLV header at offset %d", offset)
 		}
-		tlvType := binary.LittleEndian.Uint16(data[offset : offset+2])
-		tlvLen := int(binary.LittleEndian.Uint16(data[offset+2 : offset+4]))
+		tlvType := binary.BigEndian.Uint16(data[offset : offset+2])
+		tlvLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
 		offset += 4
 
 		if offset+tlvLen > len(data) {
@@ -67,6 +58,12 @@ func ParsePacket(data []byte) (*Device, error) {
 
 		value := data[offset : offset+tlvLen]
 		offset += tlvLen
+
+		slog.Debug("mndp: TLV",
+			"type", tlvType,
+			"length", tlvLen,
+			"hex", fmt.Sprintf("% 02x", value),
+		)
 
 		switch tlvType {
 		case tlvMAC:
@@ -87,13 +84,46 @@ func ParsePacket(data []byte) (*Device, error) {
 			dev.SoftwareID = string(value)
 		case tlvBoard:
 			dev.Board = string(value)
+		case tlvUnpack:
+			if tlvLen == 1 {
+				dev.Unpack = value[0] != 0
+			}
+		case tlvIPv6:
+			if tlvLen == 16 {
+				dev.IPv6Address = net.IP(value).String()
+			}
+			// Other lengths silently skipped
+		case tlvSourceInterfaceName:
+			dev.SourceInterfaceName = string(value)
 		case tlvIPv4:
 			if tlvLen == 4 {
 				dev.IPv4Address = net.IP(value).String()
 			}
-			// tlvLen == 16 is IPv6 — silently skipped (not yet supported)
+		case tlvUnknown18:
+			// Observed but undocumented; silently skip
+		default:
+			slog.Debug("mndp: skipping unknown TLV",
+				"type", tlvType,
+				"length", tlvLen,
+				"hex", fmt.Sprintf("% 02x", value),
+			)
 		}
 	}
+
+	slog.Debug("mndp: parsed device",
+		"mac", dev.MACAddress,
+		"identity", dev.Identity,
+		"version", dev.Version,
+		"platform", dev.Platform,
+		"uptime", dev.Uptime,
+		"softwareid", dev.SoftwareID,
+		"board", dev.Board,
+		"unpack", dev.Unpack,
+		"ipv6", dev.IPv6Address,
+		"rmote interface", dev.SourceInterfaceName,
+		"ipv4", dev.IPv4Address,
+		"local interface", dev.InterfaceName,
+	)
 
 	if dev.MACAddress == "" {
 		return nil, fmt.Errorf("mndp: missing required MAC address TLV")

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -99,10 +99,12 @@ func ParsePacket(data []byte) (*Device, error) {
 			}
 		case tlvUnknown18:
 			// Observed but undocumented; silently skip
-			slog.Debug("mndp: skipping unknown TLV 18",
+			slog.Debug("mndp: skipping unknown TLV",
 				"type", tlvType,
 				"length", tlvLen,
 				"hex", fmt.Sprintf("% 02x", value),
+				"identity", dev.Identity,
+				"mac", dev.MACAddress,
 			)
 		default:
 			slog.Debug("mndp: skipping unknown TLV",

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -123,9 +123,9 @@ func ParsePacket(data []byte) (*Device, error) {
 		"board", dev.Board,
 		"unpack", dev.Unpack,
 		"ipv6", dev.IPv6Address,
-		"remote interface", dev.SourceInterfaceName,
+		"remote_interface", dev.SourceInterfaceName,
 		"ipv4", dev.IPv4Address,
-		"local interface", dev.InterfaceName,
+		"local_interface", dev.InterfaceName,
 	)
 
 	if dev.MACAddress == "" {

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -3,6 +3,7 @@ package mndp
 import (
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"net"
 )
 
@@ -93,8 +94,29 @@ func ParsePacket(data []byte) (*Device, error) {
 			}
 		case tlvUnknown18:
 			// Observed but undocumented; silently skip
+		default:
+			slog.Debug("mndp: skipping unknown TLV",
+				"type", tlvType,
+				"length", tlvLen,
+				"hex", fmt.Sprintf("% 02x", value),
+			)
 		}
 	}
+
+	slog.Debug("mndp: parsed device",
+		"mac", dev.MACAddress,
+		"identity", dev.Identity,
+		"version", dev.Version,
+		"platform", dev.Platform,
+		"uptime", dev.Uptime,
+		"softwareid", dev.SoftwareID,
+		"board", dev.Board,
+		"unpack", dev.Unpack,
+		"ipv6", dev.IPv6Address,
+		"remote interface", dev.SourceInterfaceName,
+		"ipv4", dev.IPv4Address,
+		"local interface", dev.InterfaceName,
+	)
 
 	if dev.MACAddress == "" {
 		return nil, fmt.Errorf("mndp: missing required MAC address TLV")

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -3,7 +3,6 @@ package mndp
 import (
 	"encoding/binary"
 	"fmt"
-	"log/slog"
 	"net"
 )
 
@@ -26,12 +25,11 @@ const (
 //
 // Wire format:
 //
-//		// Header: [1B seq_lo] [1B msg-type] [1B seq_hi or reserved] [1B counter/reserved]
-//	      [TLV…][2B type LE][2B length LE][length bytes value]
+//	Header: [1B seq_lo] [1B msg-type] [1B seq_hi or reserved] [1B counter/reserved]
+//	[TLV…][2B type BE][2B length BE][length bytes value]
 //
 // Returns an error for:
 //   - Packets shorter than 4 bytes
-//   - msg-type 0x0000 (request) or unknown types
 //   - Truncated TLV values
 //   - Missing MAC address TLV
 //   - Missing Identity TLV
@@ -58,12 +56,6 @@ func ParsePacket(data []byte) (*Device, error) {
 
 		value := data[offset : offset+tlvLen]
 		offset += tlvLen
-
-		slog.Debug("mndp: TLV",
-			"type", tlvType,
-			"length", tlvLen,
-			"hex", fmt.Sprintf("% 02x", value),
-		)
 
 		switch tlvType {
 		case tlvMAC:
@@ -101,29 +93,8 @@ func ParsePacket(data []byte) (*Device, error) {
 			}
 		case tlvUnknown18:
 			// Observed but undocumented; silently skip
-		default:
-			slog.Debug("mndp: skipping unknown TLV",
-				"type", tlvType,
-				"length", tlvLen,
-				"hex", fmt.Sprintf("% 02x", value),
-			)
 		}
 	}
-
-	slog.Debug("mndp: parsed device",
-		"mac", dev.MACAddress,
-		"identity", dev.Identity,
-		"version", dev.Version,
-		"platform", dev.Platform,
-		"uptime", dev.Uptime,
-		"softwareid", dev.SoftwareID,
-		"board", dev.Board,
-		"unpack", dev.Unpack,
-		"ipv6", dev.IPv6Address,
-		"rmote interface", dev.SourceInterfaceName,
-		"ipv4", dev.IPv4Address,
-		"local interface", dev.InterfaceName,
-	)
 
 	if dev.MACAddress == "" {
 		return nil, fmt.Errorf("mndp: missing required MAC address TLV")

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -22,12 +22,13 @@ const (
 	tlvUnknown18           = 18 // observed in the wild; purpose unknown
 )
 
-// ParsePacket parses an MNDP response packet and returns the discovered Device.
+// ParsePacket parses an MNDP packet and returns the discovered Device.
 //
 // Wire format:
 //
-//	Header: [1B seq_lo] [1B msg-type] [1B seq_hi or reserved] [1B counter/reserved]
-//	[TLV…][2B type BE][2B length BE][length bytes value]
+//	Headers: [1B seq_lo or reserved] [1B msg-type or reserved]
+//               [1B seq_hi or reserved] [1B counter or reserved]
+//	Payload: [TLV…][2B type BE][2B length BE][length bytes value]
 //
 // Returns an error for:
 //   - Packets shorter than 4 bytes
@@ -38,6 +39,10 @@ func ParsePacket(data []byte) (*Device, error) {
 	if len(data) < 4 {
 		return nil, fmt.Errorf("mndp: packet too short (%d bytes)", len(data))
 	}
+
+	slog.Debug("mndp: packet first 4 bytes",
+		"hex", fmt.Sprintf("% 02x", data[0:4]),
+	)
 
 	dev := &Device{}
 	offset := 4
@@ -94,6 +99,11 @@ func ParsePacket(data []byte) (*Device, error) {
 			}
 		case tlvUnknown18:
 			// Observed but undocumented; silently skip
+			slog.Debug("mndp: skipping unknown TLV 18",
+				"type", tlvType,
+				"length", tlvLen,
+				"hex", fmt.Sprintf("% 02x", value),
+			)
 		default:
 			slog.Debug("mndp: skipping unknown TLV",
 				"type", tlvType,

--- a/common/mndp/parser.go
+++ b/common/mndp/parser.go
@@ -26,9 +26,9 @@ const (
 //
 // Wire format:
 //
-//	Headers: [1B seq_lo or reserved] [1B msg-type or reserved]
-//               [1B seq_hi or reserved] [1B counter or reserved]
-//	Payload: [TLV…][2B type BE][2B length BE][length bytes value]
+//		Headers: [1B seq_lo or reserved] [1B msg-type or reserved]
+//	              [1B seq_hi or reserved] [1B counter or reserved]
+//		Payload: [TLV…][2B type BE][2B length BE][length bytes value]
 //
 // Returns an error for:
 //   - Packets shorter than 4 bytes

--- a/common/mndp/parser_test.go
+++ b/common/mndp/parser_test.go
@@ -98,7 +98,10 @@ func TestParsePacket_IPv6OnlyAddress(t *testing.T) {
 		t.Fatalf("ParsePacket() unexpected error = %v", err)
 	}
 	if dev.IPv4Address != "" {
-		t.Errorf("IPv4Address = %q, want empty (IPv6 should be skipped)", dev.IPv4Address)
+		t.Errorf("IPv4Address = %q, want empty", dev.IPv4Address)
+	}
+	if dev.IPv6Address != "fe80::" {
+		t.Errorf("IPv6Address = %q, want %q", dev.IPv6Address, "fe80::")
 	}
 }
 
@@ -130,6 +133,9 @@ func TestParsePacket_BothIPv4AndIPv6(t *testing.T) {
 	}
 	if dev.IPv4Address != "10.0.0.1" {
 		t.Errorf("IPv4Address = %q, want %q", dev.IPv4Address, "10.0.0.1")
+	}
+	if dev.IPv6Address != "fe80::" {
+		t.Errorf("IPv6Address = %q, want %q", dev.IPv6Address, "fe80::")
 	}
 }
 

--- a/common/mndp/parser_test.go
+++ b/common/mndp/parser_test.go
@@ -210,3 +210,45 @@ func TestParsePacket_UnknownMsgType(t *testing.T) {
 		t.Fatal("ParsePacket() expected error for unknown msg-type, got nil")
 	}
 }
+
+func TestParsePacket_TLVEndiannessIsBigEndian(t *testing.T) {
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+
+	t.Run("big-endian-tlv-header-parses", func(t *testing.T) {
+		pkt := []byte{
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x01, // type: MAC
+			0x00, 0x06, // len: 6
+			0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+			0x00, 0x05, // type: Identity
+			0x00, 0x06, // len: 6
+			'r', 'o', 'u', 't', 'e', 'r',
+		}
+
+		dev, err := ParsePacket(pkt)
+		if err != nil {
+			t.Fatalf("ParsePacket() unexpected error for big-endian TLV header = %v", err)
+		}
+		if dev.MACAddress != "aa:bb:cc:dd:ee:ff" {
+			t.Fatalf("MACAddress = %q, want %q", dev.MACAddress, "aa:bb:cc:dd:ee:ff")
+		}
+	})
+
+	t.Run("little-endian-tlv-header-fails", func(t *testing.T) {
+		pkt := []byte{
+			0x00, 0x00, 0x00, 0x00,
+			0x01, 0x00, // type: MAC (little-endian encoded)
+			0x06, 0x00, // len: 6 (little-endian encoded)
+		}
+		pkt = append(pkt, mac...)
+		pkt = append(pkt,
+			0x05, 0x00, // type: Identity (little-endian encoded)
+			0x06, 0x00, // len: 6 (little-endian encoded)
+			'r', 'o', 'u', 't', 'e', 'r',
+		)
+
+		if _, err := ParsePacket(pkt); err == nil {
+			t.Fatal("ParsePacket() expected error for little-endian TLV header, got nil")
+		}
+	})
+}

--- a/common/mndp/parser_test.go
+++ b/common/mndp/parser_test.go
@@ -8,15 +8,12 @@ import (
 // buildTestPacket constructs a minimal valid MNDP response packet for testing.
 // mac must be 6 bytes; identity must be non-empty.
 func buildTestPacket(mac []byte, identity, version, platform string, uptime uint32, softwareID, board string, ipv4 []byte, ipv6 []byte) []byte {
-	pkt := []byte{
-		0x01, 0x00, // msg-type = 0x0001 (response), LE
-		0x00, 0x00, // sequence = 0
-	}
+	pkt := []byte{0x00, 0x00, 0x00, 0x00}
 
 	appendTLV := func(tlvType uint16, value []byte) {
 		hdr := make([]byte, 4)
-		binary.LittleEndian.PutUint16(hdr[0:2], tlvType)
-		binary.LittleEndian.PutUint16(hdr[2:4], uint16(len(value)))
+		binary.BigEndian.PutUint16(hdr[0:2], tlvType)
+		binary.BigEndian.PutUint16(hdr[2:4], uint16(len(value)))
 		pkt = append(pkt, hdr...)
 		pkt = append(pkt, value...)
 	}
@@ -48,9 +45,7 @@ func buildTestPacket(mac []byte, identity, version, platform string, uptime uint
 		appendTLV(tlvIPv4, ipv4)
 	}
 	if len(ipv6) == 16 {
-		// MNDP uses TLV type 15 for both IPv4 and IPv6, distinguished by length:
-		// 4 bytes = IPv4, 16 bytes = IPv6. The parser skips IPv6 entries silently.
-		appendTLV(tlvIPv4, ipv6)
+		appendTLV(tlvIPv6, ipv6)
 	}
 
 	return pkt
@@ -115,24 +110,19 @@ func TestParsePacket_BothIPv4AndIPv6(t *testing.T) {
 	ipv6[1] = 0x80
 
 	// Manually construct a packet with both IPv4 and IPv6 TLVs
-	pkt := []byte{
-		0x01, 0x00, // msg-type = response
-		0x00, 0x00, // sequence
-	}
+	pkt := []byte{0x00, 0x00, 0x00, 0x00}
 	appendTLV := func(tlvType uint16, value []byte) {
 		hdr := make([]byte, 4)
-		binary.LittleEndian.PutUint16(hdr[0:2], tlvType)
-		binary.LittleEndian.PutUint16(hdr[2:4], uint16(len(value)))
+		binary.BigEndian.PutUint16(hdr[0:2], tlvType)
+		binary.BigEndian.PutUint16(hdr[2:4], uint16(len(value)))
 		pkt = append(pkt, hdr...)
 		pkt = append(pkt, value...)
 	}
 	appendTLV(tlvMAC, mac)
 	appendTLV(tlvIdentity, []byte("router.home"))
-	// In MNDP, TLV type 15 (tlvIPv4) is used for both IPv4 and IPv6 addresses.
-	// The length field distinguishes them: 4 bytes = IPv4, 16 bytes = IPv6.
-	// The parser skips IPv6 entries silently.
+	// In MNDP, TLV type 17 contains IPv4 and TLV type 15 contains IPv6.
 	appendTLV(tlvIPv4, ipv4) // IPv4: length 4 → should be stored
-	appendTLV(tlvIPv4, ipv6) // IPv6: length 16 → should be skipped
+	appendTLV(tlvIPv6, ipv6) // IPv6: length 16 → should be parsed separately
 
 	dev, err := ParsePacket(pkt)
 	if err != nil {
@@ -145,10 +135,9 @@ func TestParsePacket_BothIPv4AndIPv6(t *testing.T) {
 
 func TestParsePacket_TruncatedTLV(t *testing.T) {
 	pkt := []byte{
-		0x01, 0x00, // msg-type = response
-		0x00, 0x00, // sequence
-		0x01, 0x00, // TLV type = 1 (MAC)
-		0x06, 0x00, // TLV length = 6
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x01, // TLV type = 1 (MAC)
+		0x00, 0x06, // TLV length = 6
 		// Only 2 bytes of value instead of 6 — truncated
 		0xAA, 0xBB,
 	}
@@ -162,10 +151,9 @@ func TestParsePacket_TruncatedTLV(t *testing.T) {
 func TestParsePacket_MissingMAC(t *testing.T) {
 	// Packet with identity but no MAC
 	pkt := []byte{
-		0x01, 0x00, // msg-type = response
-		0x00, 0x00, // sequence
-		0x05, 0x00, // TLV type = 5 (Identity)
-		0x06, 0x00, // TLV length = 6
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x05, // TLV type = 5 (Identity)
+		0x00, 0x06, // TLV length = 6
 		'r', 'o', 'u', 't', 'e', 'r', // "router"
 	}
 
@@ -178,10 +166,9 @@ func TestParsePacket_MissingMAC(t *testing.T) {
 func TestParsePacket_MissingIdentity(t *testing.T) {
 	// Packet with MAC but no identity
 	pkt := []byte{
-		0x01, 0x00, // msg-type = response
-		0x00, 0x00, // sequence
-		0x01, 0x00, // TLV type = 1 (MAC)
-		0x06, 0x00, // TLV length = 6
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x01, // TLV type = 1 (MAC)
+		0x00, 0x06, // TLV length = 6
 		0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
 	}
 

--- a/common/mndp/types.go
+++ b/common/mndp/types.go
@@ -2,13 +2,16 @@ package mndp
 
 // Device represents a MikroTik device discovered via MNDP.
 type Device struct {
-	MACAddress    string // TLV type 1  — canonical deduplication key (lower-case hex string, e.g. "aa:bb:cc:dd:ee:ff")
-	Identity      string // TLV type 5  — matches LLDP neighbor identity
-	Version       string // TLV type 7
-	Platform      string // TLV type 8  ("MikroTik")
-	Uptime        uint32 // TLV type 10 — seconds (4-byte LE)
-	SoftwareID    string // TLV type 11
-	Board         string // TLV type 12
-	IPv4Address   string // TLV type 15, length==4 only; IPv6 (length==16) is silently skipped
-	InterfaceName string // local NIC on which the UDP response arrived
+	MACAddress          string // TLV type 1  — canonical deduplication key (lower-case hex string, e.g. "aa:bb:cc:dd:ee:ff")
+	Identity            string // TLV type 5  — matches LLDP neighbor identity
+	Version             string // TLV type 7
+	Platform            string // TLV type 8  ("MikroTik")
+	Uptime              uint32 // TLV type 10 — seconds (4-byte LE)
+	SoftwareID          string // TLV type 11
+	Board               string // TLV type 12
+	Unpack              bool   // TLV type 14 — whether the device supports unpacking
+	IPv6Address         string // TLV type 15 — link-local or global IPv6 (not yet used)
+	SourceInterfaceName string // TLV type 16 — interface name on the remote device
+	IPv4Address         string // TLV type 17
+	InterfaceName       string // local NIC on which the UDP response arrived (set by listener, not parsed)
 }


### PR DESCRIPTION
This pull request makes several protocol and parsing improvements to the MNDP (MikroTik Neighbor Discovery Protocol) implementation. The most significant changes are updates to support new TLV types (including IPv6 and interface names), switching TLV parsing to use big-endian encoding, and enhancing device deduplication logic. It also adds detailed debug logging for easier troubleshooting.

**Protocol and Parsing Updates:**

* Added support for new TLV types: unpack capability (`tlvUnpack`), IPv6 address (`tlvIPv6`), and source interface name (`tlvSourceInterfaceName`). The TLV type numbers have been updated to reflect observed protocol changes, and an unknown TLV type is now explicitly skipped. (`[[1]](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1L17-R30)`, `[[2]](diffhunk://#diff-475802d99f5ba9e059d57a0d582b60c607abbc837fda1f1db7fd56e7acec6bf8L12-R16)`, `[[3]](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1R87-R127)`)
* TLV parsing now uses big-endian encoding instead of little-endian, matching the actual protocol wire format. (`[common/mndp/parser.goL41-R51](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1L41-R51)`)
* Added debug logging for each parsed TLV and for the final parsed device, aiding in protocol analysis and troubleshooting. (`[[1]](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1R6)`, `[[2]](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1R62-R67)`, `[[3]](diffhunk://#diff-1caa86c37c7d231109a173bbc5d0c52714f5f1b658c78912fd0f4ebec74818b1R87-R127)`)

**Listener and Deduplication Improvements:**

* The listener now binds to `0.0.0.0:5678` on all interfaces instead of requiring a usable IPv4 address per interface, improving compatibility with interfaces lacking IPv4 addresses. (`[common/mndp/listener.goL59-R68](diffhunk://#diff-540ae04b28e52aa62867054749e926113d57526bf2c3dfaf4ec050e04cace4fbL59-R68)`)
* Device deduplication logic was improved: when multiple responses are received for the same MAC address, devices with a valid IPv4 address now take precedence over those without. (`[common/mndp/listener.goL139-R142](diffhunk://#diff-540ae04b28e52aa62867054749e926113d57526bf2c3dfaf4ec050e04cace4fbL139-R142)`)